### PR TITLE
Collect the EntitySchemas used when normalizing.

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -1,0 +1,30 @@
+# Composing
+Because Enty's schemas are just functions that return new instances
+you can create factory functions to compose schema types togther
+
+## Object Entity
+```
+function entity(name, definition, options) {
+    return EntitySchema(name, {
+        definition: ObjectSchema(definition),
+        ...options
+    })
+}
+
+const user = entity('user', {
+    friendList: ArraySchema(friend)
+});
+```
+
+## Immutable Record Entity
+```
+function record(name, Record, options) {
+    return EntitySchema(name, {
+        constructor: (entity) => new Record(entity.toObject())
+        ...options
+    })
+}
+
+
+const user = record('user', UserRecord);
+```

--- a/src/EntityReducerFactory.js
+++ b/src/EntityReducerFactory.js
@@ -39,7 +39,8 @@ export default function EntityReducerFactory(config: Object): Function {
     } = config;
 
     const initialState = Map({
-        _schema: Map(schemaMap),
+        _baseSchema: Map(schemaMap),
+        _schemas: Map(),
         _result: Map(),
         _requestState: Map()
     });
@@ -97,20 +98,21 @@ export default function EntityReducerFactory(config: Object): Function {
             if(schema && payload) {
                 let previousEntities = state
                     .map(ii => ii.toObject())
-                    .delete('_schema')
+                    .delete('_actionSchema')
                     .delete('_result')
                     .delete('_requestState')
                     .toObject();
 
-                const {result, entities} = schema.normalize(payload, previousEntities);
+                const {result, entities, schemas} = schema.normalize(payload, previousEntities);
 
                 Logger.infoIf(entities.size == 0, `0 entities have been normalised with your current schema. This is the schema being used:`, schema);
                 Logger.info(`Merging any normalized entities and result into state`);
 
                 return state
                     // set results
+                    .update(state => state.merge(Map(entities).map(ii => Map(ii))))
                     .setIn(['_result', resultKey], result)
-                    .update(state => state.merge(Map(entities).map(ii => Map(ii))));
+                    .updateIn(['_schemas'], (previous) => Map(schemas).merge(previous));
             }
 
 

--- a/src/EntitySelector.js
+++ b/src/EntitySelector.js
@@ -25,7 +25,7 @@ const defaultOptions = {
 export function selectEntityByResult(state: Object, resultKey: string, options: SelectOptions = {}): any {
     const {schemaKey, stateKey} = Object.assign({}, defaultOptions, options);
     const entities = state[stateKey];
-    const schema = getIn(entities, ['_schema', schemaKey]);
+    const schema = getIn(entities, ['_baseSchema', schemaKey]);
 
     if(!schema) {
         return;
@@ -50,9 +50,9 @@ export function selectEntityByResult(state: Object, resultKey: string, options: 
  * @memberof module:Selectors
  */
 export function selectEntityById(state: Object, type: string, id: string, options: SelectOptions = {}): any {
-    const {schemaKey, stateKey} = Object.assign({}, defaultOptions, options);
+    const {stateKey} = Object.assign({}, defaultOptions, options);
     const entities = state[stateKey];
-    const schema = getIn(entities, ['_schema', schemaKey]).definition[type];
+    const schema = getIn(entities, ['_schemas', type]);
 
     if(!schema) {
         return;
@@ -70,9 +70,9 @@ export function selectEntityById(state: Object, type: string, id: string, option
  * @memberof module:Selectors
  */
 export function selectEntityByType(state: Object, type: string, options: SelectOptions = {}): any {
-    const {schemaKey, stateKey} = Object.assign({}, defaultOptions, options);
+    const {stateKey} = Object.assign({}, defaultOptions, options);
     const entities = state[stateKey];
-    const schema = ArraySchema(getIn(entities, ['_schema', schemaKey]).definition[type]);
+    const schema = ArraySchema(getIn(entities, ['_schemas', type]));
 
     if(!schema) {
         return;

--- a/src/__tests__/EntityReducerFactory-test.js
+++ b/src/__tests__/EntityReducerFactory-test.js
@@ -85,10 +85,10 @@ test('EntityReducerFactory', tt => {
 
     tt.true(
         is(
-            EntityReducer(undefined, exampleAction).get('_schema'),
+            EntityReducer(undefined, exampleAction).get('_baseSchema'),
             Map(schemaMap)
         ),
-        'Immutable version of schema is returned under _schema when reducer is called with no existing state'
+        'Immutable version of schema is returned under _baseSchema when reducer is called with no existing state'
     );
 
     tt.true(

--- a/src/__tests__/EntitySelector-test.js
+++ b/src/__tests__/EntitySelector-test.js
@@ -1,3 +1,4 @@
+//@flow
 import test from 'ava';
 import EntitySchema from '../schema/EntitySchema';
 import ObjectSchema from '../schema/ObjectSchema';
@@ -9,7 +10,7 @@ import {
     selectEntityByType
 } from '../EntitySelector';
 
-function constructState() {
+function constructState(): Object {
     var foo = EntitySchema('foo');
     var fooList = ArraySchema(foo);
     var schema = ObjectSchema({
@@ -29,7 +30,8 @@ function constructState() {
         entity: fromJS({
             ...normalized.entities,
             _result: normalized.result,
-            _schema: Map({
+            _schemas: normalized.schemas,
+            _baseSchema: Map({
                 ENTITY_RECEIVE: schema,
                 fooList
             })
@@ -41,23 +43,23 @@ function constructState() {
 //
 // selectEntityByResult()
 
-test('selectEntityByResult() should return a map for single items', tt => {
+test('selectEntityByResult() should return a map for single items', (tt: Object) => {
     tt.truthy(selectEntityByResult(constructState(), 'single').foo);
 });
 
-test('selectEntityByResult() should return an array for indexed items', tt => {
-    tt.is(selectEntityByResult(constructState(), 'fooList', 'fooList').length, 3);
+test('selectEntityByResult() should return an array for indexed items', (tt: Object) => {
+    tt.is(selectEntityByResult(constructState(), 'fooList').length, 3);
 });
 
-test('selectEntityByResult() should return nothing if the denormalize fails', tt => {
-    tt.is(selectEntityByResult({entity: fromJS({})}), undefined);
+test('selectEntityByResult() should return nothing if the denormalize fails', (tt: Object) => {
+    tt.is(selectEntityByResult({entity: fromJS({})}, 'ENTITY_RECEIVE'), undefined);
 });
 
 
 //
 // selectEntityById()
 
-test('selectEntityById() should return an item from entity state by path', tt => {
+test('selectEntityById() should return an item from entity state by path', (tt: Object) => {
     tt.is(selectEntityById(constructState(), 'foo', 'bar').get('id'), 'bar');
 });
 
@@ -65,7 +67,7 @@ test('selectEntityById() should return an item from entity state by path', tt =>
 //
 // selectEntityByType()
 
-test('selectEntityByType() should return an list of entities', tt => {
+test('selectEntityByType() should return an list of entities', (tt: Object) => {
     tt.true(List.isList(selectEntityByType(constructState(), 'foo')));
 });
 

--- a/src/decls/FlowTypes.js
+++ b/src/decls/FlowTypes.js
@@ -5,6 +5,13 @@ import {Map} from 'immutable';
 
 type NormalizeState = {
     entities: Object|Map,
+    result: Object|Map,
+    schemas: Object
+};
+
+
+type DenormalizeState = {
+    entities: Object|Map,
     result: Object|Map
 };
 

--- a/src/schema/ArraySchema.js
+++ b/src/schema/ArraySchema.js
@@ -33,9 +33,13 @@ export class ArraySchema {
     normalize(data: Array<any>, entities: Object = {}): NormalizeState {
         const {definition} = this;
         const idAttribute = definition.options.idAttribute;
+        let schemas = {};
         const result = List(data)
             .map((item: any): any => {
-                const {result} = definition.normalize(item, entities);
+                const {result, schemas: childSchemas} = definition.normalize(item, entities);
+
+                // preserve our shcemas map
+                Object.assign(schemas, childSchemas);
 
                 // If our result is our item that means we have prenoramlized data.
                 if(result === item || definition.type !== 'entity') {
@@ -45,14 +49,14 @@ export class ArraySchema {
                 return idAttribute(item).toString();
             });
 
-        return {entities, result};
+        return {entities, schemas, result};
     }
 
     /**
      * ArraySchema.denormalize
      */
-    denormalize(normalizeState: NormalizeState, path: Array<*> = []): any {
-        const {result, entities} = normalizeState;
+    denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): any {
+        const {result, entities} = denormalizeState;
         const {definition} = this;
         // Filter out any deleted keys
         if(result == null) {

--- a/src/schema/DynamicSchema.js
+++ b/src/schema/DynamicSchema.js
@@ -33,11 +33,14 @@ export class DynamicSchema {
      */
     normalize(data: Object, entities: Object = {}): NormalizeState {
         const definitionSchema = this.options.definition(data);
+        const definitionResult = definitionSchema.normalize(data, entities);
+
         return {
             entities,
+            schemas: definitionResult.schemas,
             result: {
                 resultType: 'dynamicSchemaResult',
-                definitionResult: definitionSchema.normalize(data, entities),
+                definitionResult,
                 definitionSchema
             }
         };
@@ -46,8 +49,8 @@ export class DynamicSchema {
     /**
      * DynamicSchema.denormalize
      */
-    denormalize(normalizeState: NormalizeState, path: Array<*> = []): any {
-        const {definitionResult, definitionSchema} = normalizeState.result;
+    denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): any {
+        const {definitionResult, definitionSchema} = denormalizeState.result;
         return definitionSchema.denormalize(definitionResult, path);
     }
 }

--- a/src/schema/ObjectSchema.js
+++ b/src/schema/ObjectSchema.js
@@ -44,26 +44,29 @@ export class ObjectSchema {
     normalize(data: Object, entities: Object = {}): NormalizeState {
         const {definition} = this;
         const dataMap = Map(data);
+        let schemas = {};
 
         const result = dataMap
             .keySeq()
             .reduce((result: Object, key: string): any => {
                 if(definition[key] && dataMap.get(key)) {
-                    return result.set(key, definition[key].normalize(dataMap.get(key), entities).result);
+                    const {result: childResult, schemas: childSchemas} = definition[key].normalize(dataMap.get(key), entities);
+                    Object.assign(schemas, childSchemas);
+                    return result.set(key, childResult);
                 }
 
                 return result;
             }, dataMap);
 
-        return {entities, result};
+        return {entities, schemas, result};
 
     }
 
     /**
      * ObjectSchema.denormalize
      */
-    denormalize(normalizeState: NormalizeState, path: Array<*> = []): any {
-        const {result, entities} = normalizeState;
+    denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): any {
+        const {result, entities} = denormalizeState;
         const {definition, options} = this;
         let deletedKeys = [];
 

--- a/src/schema/ValueSchema.js
+++ b/src/schema/ValueSchema.js
@@ -34,10 +34,11 @@ export class ValueSchema {
      */
     normalize(data: Object, entities: Object = {}): NormalizeState {
         const {definition, constructor} = this.options;
-        const {result} = definition.normalize(constructor(data), entities);
+        const {result, schemas} = definition.normalize(constructor(data), entities);
 
         return {
             result,
+            schemas,
             entities
         };
     }
@@ -45,8 +46,8 @@ export class ValueSchema {
     /**
      * ValueSchema.denormalize
      */
-    denormalize(normalizeState: NormalizeState, path: Array<*> = []): any {
-        return this.options.definition.denormalize(normalizeState, path);
+    denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): any {
+        return this.options.definition.denormalize(denormalizeState, path);
     }
 }
 

--- a/src/schema/__tests__/EntitySchema-test.js
+++ b/src/schema/__tests__/EntitySchema-test.js
@@ -1,24 +1,30 @@
+//@flow
 import test from 'ava';
 import {EntitySchema, ObjectSchema} from '../../index';
 import {DELETED_ENTITY} from '../SchemaConstant';
 import {fromJS} from 'immutable';
 
 var foo = EntitySchema('foo');
+var bar = EntitySchema('bar');
+var baz = EntitySchema('baz');
 
-test('EntitySchema can define definition through the `define` method', tt => {
+baz.define(ObjectSchema({bar}));
+bar.define(ObjectSchema({foo}));
+
+test('EntitySchema can define definition through the `define` method', (tt: Object) => {
     var schema = EntitySchema('foo');
     schema.define(ObjectSchema({bar: "1"}));
     tt.is(schema.options.definition.type, 'object');
 });
 
 
-test('EntitySchema can normalize entities', tt => {
+test('EntitySchema can normalize entities', (tt: Object) => {
     const {entities, result} = foo.normalize({id: "1"});
     tt.is(result, "1");
     tt.deepEqual(entities.foo["1"].toJS(), {id: "1"});
 });
 
-test('EntitySchema can denormalize entities', tt => {
+test('EntitySchema can denormalize entities', (tt: Object) => {
     const entities = fromJS({
         foo: {
             "1": {id: "1"}
@@ -31,7 +37,7 @@ test('EntitySchema can denormalize entities', tt => {
     );
 });
 
-test('EntitySchema will not cause an infinite recursion', tt => {
+test('EntitySchema will not cause an infinite recursion', (tt: Object) => {
     const foo = EntitySchema('foo');
     const bar = EntitySchema('bar');
 
@@ -58,7 +64,7 @@ test('EntitySchema will not cause an infinite recursion', tt => {
     );
 });
 
-test('EntitySchema will not denormalize null entities', tt => {
+test('EntitySchema will not denormalize null entities', (tt: Object) => {
     const schema = EntitySchema('bar');
 
     const entities = fromJS({
@@ -72,7 +78,7 @@ test('EntitySchema will not denormalize null entities', tt => {
 });
 
 
-test('EntitySchema will return DELETED_ENTITY placeholder if denormalizeFilter fails', tt => {
+test('EntitySchema will return DELETED_ENTITY placeholder if denormalizeFilter fails', (tt: Object) => {
     const entities = fromJS({
         foo: {
             "1": {id: "1", deleted: true}
@@ -86,17 +92,23 @@ test('EntitySchema will return DELETED_ENTITY placeholder if denormalizeFilter f
 });
 
 
-test('EntitySchema will not mutate input objects', tt => {
+test('EntitySchema will not mutate input objects', (tt: Object) => {
     const entityTest = {id: "1"};
     foo.normalize(entityTest, foo);
     tt.deepEqual(entityTest, {id: "1"});
 });
 
 
-test('EntitySchema can construct objects', tt => {
+test('EntitySchema can construct objects', (tt: Object) => {
     const entityTest = {id: "1"};
     foo.normalize(entityTest, foo);
     tt.deepEqual(entityTest, {id: "1"});
+});
+
+
+test('EntitySchema will collect schemas that were used', (tt: Object) => {
+    const entityTest = {id: '1', bar: {id: '2', foo: {id: '3'}}};
+    tt.deepEqual(Object.keys(baz.normalize(entityTest, baz).schemas), ['foo', 'bar', 'baz']);
 });
 
 


### PR DESCRIPTION
They are merged into state.
This lets the entity selectors select a child item out of state that wasn't
defined in the root schema.

Some state keys were renamed:
_schema is now _baseSchema
_schemas is added

Some flow type fixes were also required for this:
* Add DenormalizeState alongside  NormalizeState
* Fix some call signatures in tests