### PR TITLE
Create MultiHock factories

### DIFF
--- a/src/EntityMutationHockFactory.js
+++ b/src/EntityMutationHockFactory.js
@@ -22,7 +22,7 @@ import type {SelectOptions} from './definitions';
  * @returns {MutationHock}
  * @memberof module:Factories
  */
-export default function EntityMutationHockFactory(actionCreator: Function, selectOptions: SelectOptions): Function {
+export default function EntityMutationHockFactory(actionCreator: Function, selectOptions?: SelectOptions): Function {
 
     /**
      * Mutation is used to request or change data in response to user interaction.

--- a/src/MultiMutationHockFactory.js
+++ b/src/MultiMutationHockFactory.js
@@ -1,0 +1,20 @@
+//@flow
+import EntityMutationHockFactory from './EntityMutationHockFactory';
+import {createAllRequestAction} from './EntityApi';
+import type {SelectOptions} from './definitions';
+import type {SideEffect} from './definitions';
+
+/**
+ *
+ * @param {function} sideEffect
+ * @returns {EntityMutationHock}
+ * @memberof module:Factories
+ */
+export default function MultiMutationHockFactory(sideEffectList: Array<SideEffect>, selectOptions?: SelectOptions): Function {
+    const actionPrefix = 'ENTITY';
+    const FETCH = `${actionPrefix}_FETCH`;
+    const RECEIVE = `${actionPrefix}_RECEIVE`;
+    const ERROR = `${actionPrefix}_ERROR`;
+
+    return EntityMutationHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), selectOptions);
+}

--- a/src/MultiQueryHockFactory.js
+++ b/src/MultiQueryHockFactory.js
@@ -1,0 +1,21 @@
+//@flow
+import EntityQueryHockFactory from './EntityQueryHockFactory';
+import {createAllRequestAction} from './EntityApi';
+import type {SelectOptions} from './definitions';
+import type {SideEffect} from './definitions';
+
+
+/**
+ *
+ * @param {function} sideEffect
+ * @returns {EntityQueryHock}
+ * @memberof module:Factories
+ */
+export default function MultiQueryHockFactory(sideEffectList: Array<SideEffect>, selectOptions?: SelectOptions): Function {
+    const actionPrefix = 'ENTITY';
+    const FETCH = `${actionPrefix}_FETCH`;
+    const RECEIVE = `${actionPrefix}_RECEIVE`;
+    const ERROR = `${actionPrefix}_ERROR`;
+
+    return EntityQueryHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), selectOptions);
+}

--- a/src/__tests__/EntityApi-test.js
+++ b/src/__tests__/EntityApi-test.js
@@ -2,6 +2,7 @@
 import test from 'ava';
 import sinon from 'sinon';
 import EntityApi from '../EntityApi';
+import {createAllRequestAction} from '../EntityApi';
 
 const RESOLVE = (aa) => Promise.resolve(aa);
 const REJECT = (aa) => Promise.reject(aa);
@@ -53,4 +54,29 @@ test('ERROR action resultKey defaults to ERROR action name', (t: Object): Promis
         .then(() => {
             t.is('REJECT_ERROR', dispatch.secondCall.args[0].type);
         });
+});
+
+
+
+// Create Multi ActionCreator
+
+test('createAllRequestAction will call all sideffects', (t: Object): Promise<any> => {
+    var aa = sinon.spy();
+    var bb = sinon.spy();
+
+    return createAllRequestAction('a', 'a', 'a', [aa,bb])()(sinon.spy())
+        .then(() => {
+            t.is(aa.callCount, 1);
+            t.is(bb.callCount, 1);
+        })
+});
+
+test('createAllRequestAction will merge resulting objects', (t: Object): Promise<any> => {
+    var aa = async () => ({aa: 'aa'});
+    var bb = async () => ({bb: 'bb'});
+
+    return createAllRequestAction('a', 'a', 'a', [aa,bb])()(dd => dd)
+        .then((data) => {
+            t.deepEqual(data.payload, {aa: 'aa', bb: 'bb'});
+        })
 });

--- a/src/__tests__/MultiMutationHockFactory-test.js
+++ b/src/__tests__/MultiMutationHockFactory-test.js
@@ -1,0 +1,15 @@
+//@flow
+import test from 'ava';
+import sinon from 'sinon';
+import MultiMutationHockFactory from '../MultiMutationHockFactory';
+
+const RESOLVE = (aa) => Promise.resolve(aa);
+const REJECT = (aa) => Promise.reject(aa);
+
+
+test('MultiMutationHockFactory will return a MutationHock', (t: Object) => {
+    var aa = async () => ({aa: 'aa'});
+    var bb = async () => ({bb: 'bb'});
+
+    t.is(MultiMutationHockFactory([aa,bb]).name, 'EntityMutationHock');
+});

--- a/src/__tests__/MultiQueryHockFactory-test.js
+++ b/src/__tests__/MultiQueryHockFactory-test.js
@@ -1,0 +1,15 @@
+//@flow
+import test from 'ava';
+import sinon from 'sinon';
+import MultiQueryHockFactory from '../MultiQueryHockFactory';
+
+const RESOLVE = (aa) => Promise.resolve(aa);
+const REJECT = (aa) => Promise.reject(aa);
+
+
+test('MultiQueryHockFactory will return a QueryHock', (t: Object) => {
+    var aa = async () => ({aa: 'aa'});
+    var bb = async () => ({bb: 'bb'});
+
+    t.is(MultiQueryHockFactory([aa,bb]).name, 'EntityQueryHock');
+});

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -19,3 +19,5 @@ export type SelectOptions = {
     schemaKey?: string,
     stateKey?: string
 };
+
+export type SideEffect = (*, Object) => Promise<*>;

--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,11 @@ export {
 } from './RequestStateSelector';
 
 // Misc
-export {default as EntityQueryHockFactory} from './EntityQueryHockFactory';
 export {default as EntityMutationHockFactory} from './EntityMutationHockFactory';
+export {default as EntityQueryHockFactory} from './EntityQueryHockFactory';
 export {default as EntityReducerFactory} from './EntityReducerFactory';
+export {default as MultiMutationHockFactory} from './MultiMutationHockFactory';
+export {default as MultiQueryHockFactory} from './MultiQueryHockFactory';
 
 export {
     EmptyState,


### PR DESCRIPTION
* Add a Promise.all action creator that takes a list of sideEffects and
binds them all to one promise.
* Create Hock factories that use this action creator instead of the one
derived from the keys in the api.
* export the sideEffects map from EntityApi() to allow people to bind
the two sides together.