### PR TITLE
Fix queryCreator hashing, consolidate hock props.

### DIFF
--- a/src/EntityApi.js
+++ b/src/EntityApi.js
@@ -6,7 +6,7 @@ import EntityReducerFactory from './EntityReducerFactory';
 import EntityStoreFactory from './EntityStoreFactory';
 import {fromJS, Map} from 'immutable';
 
-import type {SelectOptions} from './definitions';
+import type {HockOptionsInput} from './definitions';
 import type {SideEffect} from './definitions';
 
 /**
@@ -116,11 +116,12 @@ export function createAllRequestAction(fetchAction: string, recieveAction: strin
  *
  * @param  {Schema} schema          A schema describing the relationships between your data
  * @param  {object} actionMap       deep object representation of api functions
- * @param  {SelectOptions} [selectOptions]
+ * @param  {HockOptionsInput} [hockOptions]
  * @return {EntityApi}
  * @memberof module:Api
  */
-export default function EntityApi(schema: Object, actionMap: Object, selectOptions: SelectOptions = {}): Object {
+export default function EntityApi(schema: Object, actionMap: Object, hockOptions: HockOptionsInput = {}): Object {
+
     return reduceActionMap(fromJS(actionMap))
         .reduce((state: Map<string, any>, sideEffect: SideEffect, action: string): Map<string, any> => {
 
@@ -137,6 +138,9 @@ export default function EntityApi(schema: Object, actionMap: Object, selectOptio
                 .map(ss => ss.replace(/^./, mm => mm.toUpperCase()))
                 .join('');
 
+
+            hockOptions.requestActionName = requestActionName;
+
             return state
                 // nested action creators
                 .setIn(requestActionPath, requestAction)
@@ -145,8 +149,8 @@ export default function EntityApi(schema: Object, actionMap: Object, selectOptio
                 .setIn(['actionTypes', FETCH], FETCH)
                 .setIn(['actionTypes', RECEIVE], RECEIVE)
                 .setIn(['actionTypes', ERROR], ERROR)
-                .set(`${requestActionName}QueryHock`, EntityQueryHockFactory(requestAction, selectOptions))
-                .set(`${requestActionName}MutationHock`, EntityMutationHockFactory(requestAction, selectOptions))
+                .set(`${requestActionName}QueryHock`, EntityQueryHockFactory(requestAction, hockOptions))
+                .set(`${requestActionName}MutationHock`, EntityMutationHockFactory(requestAction, hockOptions))
             ;
 
         }, Map())
@@ -160,7 +164,7 @@ export default function EntityApi(schema: Object, actionMap: Object, selectOptio
                 .get('actionTypes')
                 .filter((action, key) => /_RECEIVE$/g.test(key))
                 .reduce((schemaMap, key) => schemaMap.set(key, schema), Map())
-                .set(selectOptions.schemaKey || 'ENTITY_RECEIVE', schema)
+                .set(hockOptions.schemaKey || 'ENTITY_RECEIVE', schema)
                 .toObject()
             ;
 

--- a/src/EntityReducerFactory.js
+++ b/src/EntityReducerFactory.js
@@ -50,7 +50,10 @@ export default function EntityReducerFactory(config: Object): Function {
 
     // Return our constructed reducer
     return function EntityReducer(state: Map<any, any> = initialState, {type, payload, meta}: Object): Map<any, any> {
+        // debugger;
+
         Logger.info(`\n\nEntity reducer:`);
+
 
         const {
             schema = schemaMap[type],
@@ -70,15 +73,18 @@ export default function EntityReducerFactory(config: Object): Function {
         // Set Request States for BLANK/FETCH/ERROR
         if(/_FETCH$/g.test(type)) {
             if(state.getIn(requestStatePath)) {
+                Logger.info(`Setting RefetchingState for "${requestStatePath.join('.')}"`);
                 state = state.setIn(requestStatePath, RefetchingState());
             } else {
                 state = state.setIn(requestStatePath, FetchingState());
+                Logger.info(`Setting FetchingState for "${requestStatePath.join('.')}"`, state);
             }
         } else if(/_ERROR$/g.test(type)) {
+            Logger.info(`Setting ErrorState for "${requestStatePath.join('.')}"`);
             state = state.setIn(requestStatePath, ErrorState(payload));
         }
 
-        Logger.info(`Setting _requestState for "${resultKey}"`);
+
 
         // If the action is a FETCH and the user hasn't negated the resultResetOnFetch
         if(resultResetOnFetch && /_FETCH$/g.test(type)) {
@@ -111,15 +117,20 @@ export default function EntityReducerFactory(config: Object): Function {
                     // set results
                     .update(state => state.merge(Map(entities).map(ii => Map(ii))))
                     .setIn(['_result', resultKey], result)
-                    .updateIn(['_schemas'], (previous) => Map(schemas).merge(previous));
+                    .updateIn(['_schemas'], (previous) => Map(schemas).merge(previous))
+                    .update((state: *): * => {
+                        Logger.silly('state', state);
+                        return state;
+                    })
+                ;
             }
 
 
-            Logger.infoIf(!schema, `Schema is not defined, no entity data has been changed`);
-            Logger.infoIf(!payload, `Payload is not defined, no entity data has been changed`);
+            Logger.infoIf(!schema, `Schema is not defined, no entity data has been changed`, state);
+            Logger.infoIf(!payload, `Payload is not defined, no entity data has been changed`, state);
         }
 
-        Logger.info(`Type is not *_RECEIVE, no entity data has been changed`);
+        Logger.info(`Type is not *_RECEIVE, no entity data has been changed`, state);
         return state;
     };
 }

--- a/src/EntitySelector.js
+++ b/src/EntitySelector.js
@@ -4,7 +4,6 @@
 import {Iterable, Map} from 'immutable';
 import ListSchema from './schema/ListSchema';
 import {getIn, get} from 'stampy/lib/util/CollectionUtils';
-import type {SelectOptions} from './definitions';
 
 const defaultOptions = {
     schemaKey: 'ENTITY_RECEIVE',
@@ -23,7 +22,7 @@ const defaultOptions = {
  * @return {object} entity map
  * @memberof module:Selectors
  */
-export function selectEntityByResult(state: Object, resultKey: string, options: SelectOptions = {}): any {
+export function selectEntityByResult(state: Object, resultKey: string, options: Object = {}): any {
     const {schemaKey, stateKey} = Object.assign({}, defaultOptions, options);
     const entities = state[stateKey];
     const schema = getIn(entities, ['_baseSchema', schemaKey]);
@@ -50,7 +49,7 @@ export function selectEntityByResult(state: Object, resultKey: string, options: 
  * @return {object} entity map
  * @memberof module:Selectors
  */
-export function selectEntityById(state: Object, type: string, id: string, options: SelectOptions = {}): any {
+export function selectEntityById(state: Object, type: string, id: string, options: Object = {}): any {
     const {stateKey} = Object.assign({}, defaultOptions, options);
     const entities = state[stateKey];
     const schema = getIn(entities, ['_schemas', type]);
@@ -70,7 +69,7 @@ export function selectEntityById(state: Object, type: string, id: string, option
  * @return {Immutable.List} entity list
  * @memberof module:Selectors
  */
-export function selectEntityByType(state: Object, type: string, options: SelectOptions = {}): any {
+export function selectEntityByType(state: Object, type: string, options: Object = {}): any {
     const {stateKey} = Object.assign({}, defaultOptions, options);
     const entities = state[stateKey];
     const schema = ListSchema(getIn(entities, ['_schemas', type]));

--- a/src/MultiMutationHockFactory.js
+++ b/src/MultiMutationHockFactory.js
@@ -1,7 +1,7 @@
 //@flow
 import EntityMutationHockFactory from './EntityMutationHockFactory';
 import {createAllRequestAction} from './EntityApi';
-import type {SelectOptions} from './definitions';
+import type {HockOptionsInput} from './definitions';
 import type {SideEffect} from './definitions';
 
 /**
@@ -10,11 +10,11 @@ import type {SideEffect} from './definitions';
  * @returns {EntityMutationHock}
  * @memberof module:Factories
  */
-export default function MultiMutationHockFactory(sideEffectList: Array<SideEffect>, selectOptions?: SelectOptions): Function {
+export default function MultiMutationHockFactory(sideEffectList: Array<SideEffect>, hockOptions?: HockOptionsInput): Function {
     const actionPrefix = 'ENTITY';
     const FETCH = `${actionPrefix}_FETCH`;
     const RECEIVE = `${actionPrefix}_RECEIVE`;
     const ERROR = `${actionPrefix}_ERROR`;
 
-    return EntityMutationHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), selectOptions);
+    return EntityMutationHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), hockOptions);
 }

--- a/src/MultiQueryHockFactory.js
+++ b/src/MultiQueryHockFactory.js
@@ -1,7 +1,7 @@
 //@flow
 import EntityQueryHockFactory from './EntityQueryHockFactory';
 import {createAllRequestAction} from './EntityApi';
-import type {SelectOptions} from './definitions';
+import type {HockOptionsInput} from './definitions';
 import type {SideEffect} from './definitions';
 
 
@@ -11,11 +11,11 @@ import type {SideEffect} from './definitions';
  * @returns {EntityQueryHock}
  * @memberof module:Factories
  */
-export default function MultiQueryHockFactory(sideEffectList: Array<SideEffect>, selectOptions?: SelectOptions): Function {
+export default function MultiQueryHockFactory(sideEffectList: Array<SideEffect>, hockOptions?: HockOptionsInput): Function {
     const actionPrefix = 'ENTITY';
     const FETCH = `${actionPrefix}_FETCH`;
     const RECEIVE = `${actionPrefix}_RECEIVE`;
     const ERROR = `${actionPrefix}_ERROR`;
 
-    return EntityQueryHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), selectOptions);
+    return EntityQueryHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), hockOptions);
 }

--- a/src/RequestStateSelector.js
+++ b/src/RequestStateSelector.js
@@ -1,5 +1,6 @@
 // @flow
 import {EmptyState} from './RequestState';
+import Logger from './Logger';
 
 const defaultOptions = {
     stateKey: 'entity'
@@ -18,6 +19,7 @@ const defaultOptions = {
  */
 export default function selectRequestState(state: Object, requestStateKey: string, options?: ?Object): any {
     const {stateKey} = Object.assign({}, defaultOptions, options);
+    Logger.silly('Selecting RequestState:', `${stateKey}._requestState.${requestStateKey}`, state);
     return state[stateKey]
         .getIn(['_requestState', requestStateKey], EmptyState());
 }

--- a/src/__tests__/EntityQueryHockFactory-test.js
+++ b/src/__tests__/EntityQueryHockFactory-test.js
@@ -45,12 +45,12 @@ test('resultKey is derived either from the metaOverride or a hash of the queryCr
     };
 
     const sideEffectB = (aa: any, bb: any) => {
-        tt.is(bb.resultKey, 469309513);
+        tt.is(bb.resultKey, '431296113');
     };
 
 
-    var ComponentA = EntityQueryHockFactory(sideEffectA)(NOOP, ['keys'], {resultKey: 'foo'})(NOOP_COMPONENT);
-    var ComponentB = EntityQueryHockFactory(sideEffectB)(NOOP, ['keys'])(NOOP_COMPONENT);
+    var ComponentA = EntityQueryHockFactory(sideEffectA)(NOOP, {resultKey: 'foo'})(NOOP_COMPONENT);
+    var ComponentB = EntityQueryHockFactory(sideEffectB)(NOOP)(NOOP_COMPONENT);
 
     shallow(<ComponentA store={STORE}/>)
         .dive()
@@ -73,7 +73,7 @@ test('requestState will return an empty RequestState for unknown resultKey', (tt
         return <div></div>;
     };
 
-    var Component = EntityQueryHockFactory(NOOP)(NOOP, [], {resultKey: 'blah'})(Child);
+    var Component = EntityQueryHockFactory(NOOP)(NOOP, {resultKey: 'blah'})(Child);
 
     shallow(<Component store={STORE}/>)
         .dive()
@@ -87,7 +87,7 @@ test('EntityQueryHockFactory will group props if a `group` config is provided', 
         return <div></div>;
     };
 
-    var Component = EntityQueryHockFactory(NOOP)(NOOP, [], {group: 'fooGroup'})(Child);
+    var Component = EntityQueryHockFactory(NOOP)(NOOP, {group: 'fooGroup'})(Child);
 
     shallow(<Component store={STORE}/>)
         .dive()

--- a/src/decls/JsdocTypes.js
+++ b/src/decls/JsdocTypes.js
@@ -40,7 +40,7 @@
 /**
  * Configuration options passed to selectors for accessing state. (Basic uses cases wont need this)
  *
- * @typedef {object} SelectOptions
+ * @typedef {object} HockOptions
  * @property {string} [schemaKey=ENTITY_RECEIVE]
  * @property {string} [stateKey=entity] - redux key to store entity state at.
  */

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -15,9 +15,28 @@ export type DenormalizeState = {
     result: any
 };
 
-export type SelectOptions = {
+export type HockOptions = {
+    group?: ?string,
+    onMutateProp?: string,
+    propChangeKeys: Array<string>,
+    propUpdate: (Object) => Object,
+    requestActionName?: string,
+    resultKey?: string,
     schemaKey?: string,
     stateKey?: string
 };
 
+export type HockOptionsInput = {
+    group?: ?string,
+    onMutateProp?: string,
+    propChangeKeys?: Array<string>,
+    propUpdate?: (Object) => Object,
+    requestActionName?: string,
+    resultKey?: string,
+    schemaKey?: string,
+    stateKey?: string
+};
+
+
 export type SideEffect = (*, Object) => Promise<*>;
+

--- a/src/utils/Connect.js
+++ b/src/utils/Connect.js
@@ -1,5 +1,6 @@
 //@flow
 import {connect} from 'react-redux';
+import type {HockOptions} from '../definitions';
 
 
 const defaultOptions = {
@@ -10,7 +11,7 @@ const defaultOptions = {
  * Connect
  * @function
  */
-export default function Connect(connector?: Function, options: Object = {}): Function {
+export default function Connect(connector?: Function, options?: HockOptions): Function {
     const {stateKey} = Object.assign({}, defaultOptions, options);
 
     return connect(


### PR DESCRIPTION
* Passes requestActionName into the the hock factories and uses that in
the hashing method. This means that the query creator can be undefined
or return generic content without breaking the resultKey hashing.

* selectOptions and metaOverride are now just one HockOptions.
* Paths can be passed into hock options as propUpdateKeys
* HockOptions.propUpdate can be used to update the selected state before
it is given to the component as props