### PR TITLE
Add updateResultKey to hock options to allow render control of resultKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test-all": "yarn lint && yarn flow && yarn coverage"
   },
   "peerDependencies": {
-    "redux": "^3.6.0",
-    "react-redux": ">=4"
+    "react-redux": ">=4",
+    "redux": "^3.6.0"
   },
   "dependencies": {
     "fronads": "^0.17.0",
@@ -58,6 +58,7 @@
     "proto-blueflag-test": "git+ssh://git@github.com/blueflag/proto-blueflag-test.git#v0.8.0",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
+    "react-redux": "^5.0.6",
     "redux": "^3.6.0",
     "require.async": "^0.1.1"
   }

--- a/src/EntityApi.js
+++ b/src/EntityApi.js
@@ -149,8 +149,8 @@ export default function EntityApi(schema: Object, actionMap: Object, hockOptions
                 .setIn(['actionTypes', FETCH], FETCH)
                 .setIn(['actionTypes', RECEIVE], RECEIVE)
                 .setIn(['actionTypes', ERROR], ERROR)
-                .set(`${requestActionName}QueryHock`, EntityQueryHockFactory(requestAction, hockOptions))
-                .set(`${requestActionName}MutationHock`, EntityMutationHockFactory(requestAction, hockOptions))
+                .set(`${requestActionName}QueryHock`, EntityQueryHockFactory(requestAction, {...hockOptions, requestActionName}))
+                .set(`${requestActionName}MutationHock`, EntityMutationHockFactory(requestAction, {...hockOptions, requestActionName}))
             ;
 
         }, Map())

--- a/src/EntityMutationHockFactory.js
+++ b/src/EntityMutationHockFactory.js
@@ -73,19 +73,22 @@ export default function EntityMutationHockFactory(actionCreator: Function, hockO
      */
     return function EntityMutationHock(payloadCreator: Function = aa => aa, optionsOverride: HockOptionsInput): Function {
 
-        const options: HockOptions = {
-            ...hockOptions,
-            onMutateProp: 'onMutate',
-            group: null,
-            propUpdate: aa => aa,
-            propChangeKeys: [],
-            ...optionsOverride
-        };
 
         const distinctSuccessMap = new DistinctMemo((value, data) => value.successMap(() => data));
 
         return function EntityMutationHockApplier(Component: Element<any>): Element<any> {
-            const {group} = options;
+
+            const options: HockOptions = {
+                ...hockOptions,
+                onMutateProp: 'onMutate',
+                group: null,
+                propUpdate: aa => aa,
+                updateResultKey: aa => aa,
+                propChangeKeys: [],
+                ...optionsOverride
+            };
+
+            const {group, updateResultKey} = options;
 
             const blankConnect = Connect();
             const ComponentWithState = Connect((state: Object, props: Object): Object => {
@@ -119,7 +122,8 @@ export default function EntityMutationHockFactory(actionCreator: Function, hockO
                 updateMutation(props: Object) {
                     this.mutation = (data: Object) => {
                         const payload = payloadCreator(data);
-                        const resultKey = options.resultKey || fromJS({hash: payload}).hashCode() + options.requestActionName;
+                        const resultKey = updateResultKey(options.resultKey || fromJS({hash: payload}).hashCode() + options.requestActionName, props);
+
                         this.setState({resultKey});
                         props.dispatch(actionCreator(payload, {...options, resultKey}));
                     };

--- a/src/__tests__/EntityMutationHockFactory-test.js
+++ b/src/__tests__/EntityMutationHockFactory-test.js
@@ -84,3 +84,17 @@ test('EntityMutationHockFactory will group props if a `group` config is provided
     tt.is(typeof getProp('fooGroup'), 'object');
     tt.is(typeof getProp('fooGroup').onMutate, 'function');
 });
+
+
+test("EntityMutationHockFactory can be configured to update resultKey based on props", (t: Object) => {
+    const actionCreator = spy();
+    const Child = () => <div></div>;
+
+    var Component = EntityMutationHockFactory(actionCreator, {})(NOOP, {updateResultKey: (hash, props) => props.id})(Child);
+    shallow(<Component store={STORE} id="FOO" />)
+        .dive()
+        .instance()
+        .mutation();
+
+    t.is(actionCreator.firstCall.args[1].resultKey, 'FOO');
+});

--- a/src/__tests__/EntityQueryHockFactory-test.js
+++ b/src/__tests__/EntityQueryHockFactory-test.js
@@ -6,6 +6,7 @@ import {shallow} from 'enzyme';
 import {fromJS} from 'immutable';
 import EntityQueryHockFactory from '../EntityQueryHockFactory';
 import {FetchingState} from '../RequestState';
+import sinon from 'sinon';
 
 var NOOP = () => {};
 var STORE = {
@@ -93,3 +94,30 @@ test('EntityQueryHockFactory will group props if a `group` config is provided', 
         .dive()
         .dive();
 });
+
+
+test('EntityQueryHockFactory can be configured to update resultKey based on props', (t: Object) => {
+    var actionCreator = sinon.spy();
+
+    var store = {
+        subscribe: STORE.subscribe,
+        dispatch: (aa) => aa,
+        getState: STORE.getState
+    };
+
+    const NOOP_COMPONENT = () => <div/>;
+    const mount = (comp) => shallow(comp)
+        .dive()
+        .instance()
+        .componentDidMount();
+
+
+    var Component = EntityQueryHockFactory(actionCreator)(NOOP, {updateResultKey: (hash, props) => props.id})(NOOP_COMPONENT);
+
+    mount(<Component store={store} id="1" />);
+    mount(<Component store={store} id="2" />);
+    mount(<Component store={store} id="3" />);
+
+    t.deepEqual(actionCreator.getCalls().map(ii => ii.args[1].resultKey), ['1', '2', '3']);
+});
+

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -21,6 +21,7 @@ export type HockOptions = {
     propChangeKeys: Array<string>,
     propUpdate: (Object) => Object,
     requestActionName?: string,
+    updateResultKey: (string, Object) => string,
     resultKey?: string,
     schemaKey?: string,
     stateKey?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2968,9 +2968,9 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3637,7 +3637,11 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.2.0:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.5.tgz#9fc6e737b1c4d151d8f9cae2247305d552ce748f"
+
+lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -4540,15 +4544,16 @@ react-input-autosize@^1.1.3:
     create-react-class "^15.5.2"
     prop-types "^15.5.8"
 
-react-redux@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.3.tgz#86c3b68d56e74294a42e2a740ab66117ef6c019f"
+react-redux@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
   dependencies:
-    hoist-non-react-statics "^1.0.3"
+    hoist-non-react-statics "^2.2.1"
     invariant "^2.0.0"
     lodash "^4.2.0"
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
+    prop-types "^15.5.10"
 
 react-select@^1.0.0-rc.4:
   version "1.0.0-rc.4"


### PR DESCRIPTION
Three kinds of hock scopes: Factory, Applier, Component.
If you use 1 applier for different components they will all get the same
result key. updateResultKey is a thunk in the the applier that lets
components use props to override or extend the resultKey generated by the
applier.