### PR TITLE
Create a schema heirachy so that we can have Keyed and Child schemas.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,4 +11,8 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowBug
 <PROJECT_ROOT>/.nyc_output/.*
 <PROJECT_ROOT>/scripts/.*
 <PROJECT_ROOT>/example/.*
+<PROJECT_ROOT>/node_modules/documentation
+<PROJECT_ROOT>/node_modules/graphql
+<PROJECT_ROOT>/node_modules/unmutable
 <PROJECT_ROOT>/.*/gatsby-node.js
+<PROJECT_ROOT>/packages/enty-docs/.*

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import {
 var user = EntitySchema('user');
 var userList = ListSchema(user);
 
-user.define(MapSchema({
+user.set(MapSchema({
     friendList: userList
 }))
 

--- a/flow-typed/graphql.js
+++ b/flow-typed/graphql.js
@@ -1,0 +1,4 @@
+//@flow
+declare module "graphql" {
+    declare module.exports: any;
+}

--- a/flow-typed/unmutable.js
+++ b/flow-typed/unmutable.js
@@ -1,0 +1,4 @@
+//@flow
+declare module "unmutable" {
+    declare module.exports: any;
+}

--- a/packages/enty-docs/docs/getting-started.md
+++ b/packages/enty-docs/docs/getting-started.md
@@ -19,7 +19,7 @@ import {
 var user = EntitySchema('user');
 var userList = ListSchema(user);
 
-user.define(MapSchema({
+user.set(MapSchema({
     friendList: userList
 }))
 

--- a/packages/enty-docs/src/templates/DocumentationTemplate.jsx
+++ b/packages/enty-docs/src/templates/DocumentationTemplate.jsx
@@ -21,6 +21,8 @@ export default function DocumentationTemplate(props: Object): Node {
             const {returns} = node;
             const {description} = node;
 
+            console.log(node);
+
             const prettyName = name === 'constructor' ? node.fields.name : name;
             const typeAllLiteral = ii => ii.type === 'AllLiteral' ? '*' : ii.name;
 

--- a/packages/enty/README.md
+++ b/packages/enty/README.md
@@ -48,7 +48,7 @@ import {
 var user = EntitySchema('user');
 var userList = ListSchema(user);
 
-user.define(MapSchema({
+user.set(MapSchema({
     friendList: userList
 }))
 

--- a/packages/enty/src/ArraySchema.js
+++ b/packages/enty/src/ArraySchema.js
@@ -2,22 +2,24 @@
 import {DELETED_ENTITY} from './util/SchemaConstant';
 import type {NormalizeState} from './util/definitions';
 import type {DenormalizeState} from './util/definitions';
+import type {Schema} from './util/definitions';
+import type {Structure} from './util/definitions';
+import type {StructureInput} from './util/definitions';
+import type {ChildDefinition} from './util/definitions';
+import Child from './abstract/Child';
 
 /**
  * Class for array schema.
  */
-export class ArraySchema {
-    type: string;
-    definition: Object;
-    options: Object;
+export class ArraySchema extends Child implements Schema<Structure> {
+    options: Structure;
 
     /**
      * Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptate nobis quas exercitationem, eum, asperiores ut, perferendis harum beatae laborum magni assumenda enim qui incidunt ratione quia fugit praesentium dignissimos placeat.
      * @param {Schema} definition
      */
-    constructor(definition: Object, options: Object = {}) {
-        this.type = 'array';
-        this.definition = definition;
+    constructor(definition: ChildDefinition, options: StructureInput = {}) {
+        super(definition);
         this.options = {
             constructor: item => item,
             ...options
@@ -30,6 +32,9 @@ export class ArraySchema {
     normalize(data: Array<any>, entities: Object = {}): NormalizeState {
         const {definition} = this;
         const {constructor} = this.options;
+        // const {denormalizeFilter} = this.options;
+        // console.log(denormalizeFilter());
+
 
         let schemas = {};
         const result = constructor(data)

--- a/packages/enty/src/DynamicSchema.js
+++ b/packages/enty/src/DynamicSchema.js
@@ -1,6 +1,9 @@
 // @flow
+import Child from './abstract/Child';
 import type {NormalizeState} from './util/definitions';
 import type {DenormalizeState} from './util/definitions';
+import type {Schema} from './util/definitions';
+// import type {Structure} from './util/definitions';
 
 /**
  * @module Schema
@@ -11,23 +14,14 @@ import type {DenormalizeState} from './util/definitions';
  *
  * @memberof module:Schema
  */
-export class DynamicSchema {
-    type: string;
+export class DynamicSchema extends Child implements Schema<*> {
     options: Object;
     constructor(definition: Function, options: Object = {}) {
-        this.type = 'dynamic';
+        super(definition);
         this.options = {
             definition,
             ...options
         };
-    }
-
-    /**
-     * DynamicSchema.define
-     */
-    define(definition: any): DynamicSchema {
-        this.options.definition = definition;
-        return this;
     }
 
     /**

--- a/packages/enty/src/ListSchema.js
+++ b/packages/enty/src/ListSchema.js
@@ -1,7 +1,7 @@
 // @flow
 import {List} from 'immutable';
 import {ArraySchema} from './ArraySchema';
-
+import type {StructureInput} from './util/definitions';
 
 export class ListSchema extends ArraySchema {
 
@@ -11,12 +11,9 @@ export class ListSchema extends ArraySchema {
      * @param {Schema} definition
      * The defition of the list
      */
-    constructor(definition: Object, options: Object = {}): ListSchema {
+    constructor(definition: Object, options: StructureInput = {}) {
         super(definition, options);
-        this.type = 'list';
-
         this.options = {
-            ...this.options,
             constructor: item => List(item),
             merge: (previous, next) => previous.merge(next),
             ...options

--- a/packages/enty/src/MapSchema.js
+++ b/packages/enty/src/MapSchema.js
@@ -1,20 +1,22 @@
 // @flow
 import {Map} from 'immutable';
 import {DELETED_ENTITY, type DeletedEntity} from './util/SchemaConstant';
+import Keyed from './abstract/Keyed';
 import type {NormalizeState} from './util/definitions';
 import type {DenormalizeState} from './util/definitions';
+import type {KeyedDefinition} from './util/definitions';
+import type {Schema} from './util/definitions';
+import type {Structure} from './util/definitions';
+import type {StructureInput} from './util/definitions';
 
-export class MapSchema {
-    type: string;
-    definition: Object;
-    options: Object;
-
+export class MapSchema extends Keyed implements Schema<Structure> {
+    options: Structure;
     /**
      * The MapSchema is a structural schema used to define relationships in objects.
      *
      * @example
      * const user = entity('user');
-     * user.define(MapSchema({
+     * user.set(MapSchema({
      *     friends: ListSchema(user)
      * }))
      *
@@ -22,11 +24,9 @@ export class MapSchema {
      * @param {Object} options
      *
      */
-    constructor(definition: Object = {}, options: Object = {}) {
-        this.type = 'map';
-        this.definition = definition;
+    constructor(definition: KeyedDefinition = {}, options: StructureInput = {}) {
+        super(definition);
         this.options = {
-            ...this.options,
             constructor: item => Map(item),
             denormalizeFilter: item => item && !item.get('deleted'),
             merge: (previous, next) => previous.merge(next),
@@ -106,12 +106,6 @@ export class MapSchema {
             .update((ii: Map<any, any>): Map<any, any>|DeletedEntity => {
                 return options.denormalizeFilter(ii, deletedKeys) ? ii : DELETED_ENTITY;
             });
-    }
-    merge(mapSchema: Object): MapSchema {
-        return new MapSchema(
-            Object.assign({}, this.definition, mapSchema.definition),
-            Object.assign({}, this.options, mapSchema.options)
-        );
     }
 }
 

--- a/packages/enty/src/NullSchema.js
+++ b/packages/enty/src/NullSchema.js
@@ -1,0 +1,21 @@
+// @flow
+import type {Schema} from './util/definitions';
+import type {NormalizeState} from './util/definitions';
+import type {DenormalizeState} from './util/definitions';
+
+export default class NullSchema implements Schema<*> {
+    options: Object;
+    definition: *;
+    normalize(data: *, entities: Object): NormalizeState  {
+        return {
+            entities,
+            result: null,
+            schemas: {}
+        };
+    }
+
+    // eslint-disable-next-line
+    denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): * {
+        return null;
+    }
+}

--- a/packages/enty/src/NullSchema.js
+++ b/packages/enty/src/NullSchema.js
@@ -3,9 +3,16 @@ import type {Schema} from './util/definitions';
 import type {NormalizeState} from './util/definitions';
 import type {DenormalizeState} from './util/definitions';
 
+/**
+ * Null schema
+ */
 export default class NullSchema implements Schema<*> {
     options: Object;
     definition: *;
+
+    /**
+     * NullSchema.normalize
+     */
     normalize(data: *, entities: Object): NormalizeState  {
         return {
             entities,
@@ -14,6 +21,9 @@ export default class NullSchema implements Schema<*> {
         };
     }
 
+    /**
+     * NullSchema.denormalize
+     */
     // eslint-disable-next-line
     denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): * {
         return null;

--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -8,22 +8,24 @@ import type {KeyedDefinition} from './util/definitions';
 import type {Schema} from './util/definitions';
 import type {Structure} from './util/definitions';
 
+/**
+ * The ObjectSchema is a structural schema used to define relationships in objects.
+ *
+ * @example
+ * const user = entity('user');
+ * user.set(ObjectSchema({
+ *     friends: ListSchema(user)
+ * }))
+ *
+ * @param {Object} definition - an object describing any entity relationships that should be traversed.
+ * @param {Object} options
+ *
+ * @memberof ObjectSchema
+ *
+ */
 export class ObjectSchema extends Keyed implements Schema<Structure> {
     options: Structure;
 
-    /**
-     * The ObjectSchema is a structural schema used to define relationships in objects.
-     *
-     * @example
-     * const user = entity('user');
-     * user.set(ObjectSchema({
-     *     friends: ListSchema(user)
-     * }))
-     *
-     * @param {Object} definition - an object describing any entity relationships that should be traversed.
-     * @param {Object} options
-     *
-     */
     constructor(definition: KeyedDefinition = {}, options: Object = {}) {
         super(definition);
         this.options = {

--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -1,20 +1,22 @@
 // @flow
 import {IdentityFactory as Identity} from 'fronads/lib/Identity';
 import {DELETED_ENTITY, type DeletedEntity} from './util/SchemaConstant';
+import Keyed from './abstract/Keyed';
 import type {NormalizeState} from './util/definitions';
 import type {DenormalizeState} from './util/definitions';
+import type {KeyedDefinition} from './util/definitions';
+import type {Schema} from './util/definitions';
+import type {Structure} from './util/definitions';
 
-export class ObjectSchema {
-    type: string;
-    definition: Object;
-    options: Object;
+export class ObjectSchema extends Keyed implements Schema<Structure> {
+    options: Structure;
 
     /**
      * The ObjectSchema is a structural schema used to define relationships in objects.
      *
      * @example
      * const user = entity('user');
-     * user.define(ObjectSchema({
+     * user.set(ObjectSchema({
      *     friends: ListSchema(user)
      * }))
      *
@@ -22,9 +24,8 @@ export class ObjectSchema {
      * @param {Object} options
      *
      */
-    constructor(definition: Object = {}, options: Object = {}) {
-        this.type = 'object';
-        this.definition = definition;
+    constructor(definition: KeyedDefinition = {}, options: Object = {}) {
+        super(definition);
         this.options = {
             constructor: item => ({...item}),
             denormalizeFilter: item => item && !item.deleted,
@@ -104,12 +105,6 @@ export class ObjectSchema {
                 return options.denormalizeFilter(item, deletedKeys) ? item : DELETED_ENTITY;
             })
             .value();
-    }
-    merge(objectSchema: Object): ObjectSchema {
-        return new ObjectSchema(
-            Object.assign({}, this.definition, objectSchema.definition),
-            Object.assign({}, this.options, objectSchema.options)
-        );
     }
 }
 

--- a/packages/enty/src/ValueSchema.js
+++ b/packages/enty/src/ValueSchema.js
@@ -1,6 +1,9 @@
 // @flow
+import Child from './abstract/Child';
 import type {NormalizeState} from './util/definitions';
 import type {DenormalizeState} from './util/definitions';
+import type {Schema} from './util/definitions';
+import type {Entity} from './util/definitions';
 
 /**
  * @module Schema
@@ -11,32 +14,23 @@ import type {DenormalizeState} from './util/definitions';
  *
  * @memberof module:Schema
  */
-export class ValueSchema {
-    type: string;
-    options: Object;
-    constructor(definition: Function, options: Object = {}) {
-        this.type = 'value';
+export class ValueSchema extends Child implements Schema<Entity> {
+    options: Entity;
+
+    constructor(definition: Schema<Entity>, options: Object = {}) {
+        super(definition);
         this.options = {
-            definition,
             constructor: item => ({id: item}),
             ...options
         };
     }
 
     /**
-     * ValueSchema.define
-     */
-    define(definition: any): ValueSchema {
-        this.options.definition = definition;
-        return this;
-    }
-
-    /**
      * ValueSchema.normalize
      */
     normalize(data: *, entities: Object = {}): NormalizeState {
-        const {definition, constructor} = this.options;
-        const {result, schemas} = definition.normalize(constructor(data), entities);
+        const {constructor} = this.options;
+        const {result, schemas} = this.definition.normalize(constructor(data), entities);
 
         return {
             result,
@@ -49,7 +43,7 @@ export class ValueSchema {
      * ValueSchema.denormalize
      */
     denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): any {
-        return this.options.definition.denormalize(denormalizeState, path);
+        return this.definition.denormalize(denormalizeState, path);
     }
 }
 

--- a/packages/enty/src/__tests__/ArraySchema-test.js
+++ b/packages/enty/src/__tests__/ArraySchema-test.js
@@ -4,7 +4,7 @@ import EntitySchema from '../EntitySchema';
 import ArraySchema from '../ArraySchema';
 import ObjectSchema from '../ObjectSchema';
 
-const foo = EntitySchema('foo').define(ObjectSchema());
+const foo = EntitySchema('foo').set(ObjectSchema());
 
 test('ArraySchema can normalize arrays', (tt: *) => {
     const schema = ArraySchema(foo);
@@ -83,4 +83,32 @@ test('ArraySchema will not mutate input objects', (tt: *) => {
     tt.deepEqual(arrayTest, [{id: "1"}]);
 });
 
+
+//
+// Setters and Getters
+//
+
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
+    const schema = ArraySchema();
+    t.is(schema.set(foo), schema);
+    t.is(schema.get(), foo);
+    t.is(schema.update(() => schema.definition), schema);
+});
+
+test('ArraySchema.set will replace the definition at a key', (t: *) => {
+    const schema = ArraySchema();
+    schema.set(foo);
+    t.is(schema.definition, foo);
+});
+
+test('ArraySchema.get will return the definition at a key', (t: *) => {
+    const schema = ArraySchema(foo);
+    t.is(schema.get(), foo);
+});
+
+test('ArraySchema.update will replace the whole definition via an updater function', (t: *) => {
+    const schema = ArraySchema(foo);
+    schema.update(() => foo);
+    t.is(schema.definition, foo);
+});
 

--- a/packages/enty/src/__tests__/CompositeEntitySchema-test.js
+++ b/packages/enty/src/__tests__/CompositeEntitySchema-test.js
@@ -4,9 +4,9 @@ import EntitySchema from '../EntitySchema';
 import CompositeEntitySchema from '../CompositeEntitySchema';
 import MapSchema from '../MapSchema';
 
-var course = EntitySchema('course').define(MapSchema());
-var dog = EntitySchema('dog').define(MapSchema());
-var participant = EntitySchema('participant').define(MapSchema());
+var course = EntitySchema('course').set(MapSchema());
+var dog = EntitySchema('dog').set(MapSchema());
+var participant = EntitySchema('participant').set(MapSchema());
 
 var courseParticipant = CompositeEntitySchema('courseParticipant', {
     definition: participant,
@@ -100,7 +100,7 @@ test('CompositeEntitySchemas can defer their definition', (t: Object) => {
         }
     });
 
-    lateCourseParticipant.define(participant);
+    lateCourseParticipant.set(participant);
 
     t.notThrows(() => lateCourseParticipant.normalize(derek));
 });
@@ -113,7 +113,7 @@ test('CompositeEntitySchema compositeKeys will override defintion keys ', (t: Ob
         })
     });
 
-    const owl = EntitySchema('owl').define(MapSchema());
+    const owl = EntitySchema('owl').set(MapSchema());
 
     var catOwl = CompositeEntitySchema('catOwl', {
         definition: cat,
@@ -132,5 +132,30 @@ test('CompositeEntitySchema compositeKeys will override defintion keys ', (t: Ob
 
     t.truthy(entities.catOwl['sparky-hedwig']);
     t.falsy(entities.dog);
+});
+
+//
+// Getters and Setters
+//
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
+    const schema = courseParticipant;
+    t.is(schema.set(dog), schema);
+    t.is(schema.get(), dog);
+    t.is(schema.update(() => schema.definition), schema);
+});
+
+test('set will replace the definition at a key', (t: *) => {
+    const schema = courseParticipant
+    schema.set(dog);
+    t.is(schema.definition, dog);
+});
+
+test('get will return the definition at a key', (t: *) => {
+    t.is(courseParticipant.get(), dog);
+});
+
+test('update will replace the whole definition via an updater function', (t: *) => {
+    courseParticipant.update(() => dog);
+    t.is(courseParticipant.definition, dog);
 });
 

--- a/packages/enty/src/__tests__/DynamicSchema-test.js
+++ b/packages/enty/src/__tests__/DynamicSchema-test.js
@@ -5,9 +5,9 @@ import ListSchema from '../ListSchema';
 import DynamicSchema from '../DynamicSchema';
 import MapSchema from '../MapSchema';
 
-const foo = EntitySchema('foo').define(MapSchema());
-const bar = EntitySchema('bar').define(MapSchema());
-const baz = EntitySchema('baz').define(MapSchema());
+const foo = EntitySchema('foo').set(MapSchema());
+const bar = EntitySchema('bar').set(MapSchema());
+const baz = EntitySchema('baz').set(MapSchema());
 
 const fooBarBaz = DynamicSchema((data: *): * => {
     switch(data.type || data.get('type')) {
@@ -78,10 +78,30 @@ test('DynamicSchema.normalize on to existing data', (tt: *) => {
     tt.deepEqual(output.entities.baz['2'].toJS(), second[1]);
 });
 
-test('DynamicSchema can set definition through the `define` method', (tt: *) => {
-    const schema = DynamicSchema();
-    schema.define(() => {});
 
-    tt.is(typeof schema.options.definition, 'function');
+//
+// Getters and Setters
+//
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
+    const schema = DynamicSchema();
+    t.is(schema.set(fooBarBaz), schema);
+    t.is(schema.get(), fooBarBaz);
+    t.is(schema.update(() => schema.definition), schema);
 });
 
+test('set will replace the definition at a key', (t: *) => {
+    const schema = DynamicSchema();
+    schema.set(fooBarBaz);
+    t.is(schema.definition, fooBarBaz);
+});
+
+test('get will return the definition at a key', (t: *) => {
+    const schema = DynamicSchema(fooBarBaz);
+    t.is(schema.get(), fooBarBaz);
+});
+
+test('update will replace the whole definition via an updater function', (t: *) => {
+    const schema = DynamicSchema(fooBarBaz);
+    schema.update(() => fooBarBaz);
+    t.is(schema.definition, fooBarBaz);
+});

--- a/packages/enty/src/__tests__/EntitySchema-test.js
+++ b/packages/enty/src/__tests__/EntitySchema-test.js
@@ -9,14 +9,15 @@ var foo = EntitySchema('foo');
 var bar = EntitySchema('bar');
 var baz = EntitySchema('baz');
 
-foo.define(MapSchema({}));
-baz.define(MapSchema({bar}));
-bar.define(MapSchema({foo}));
+foo.set(MapSchema({}));
+baz.set(MapSchema({bar}));
+bar.set(MapSchema({foo}));
 
-test('EntitySchema can define definition through the `define` method', (tt: Object) => {
+test('EntitySchema can set definition through the `set` method', (tt: Object) => {
     var schema = EntitySchema('foo');
-    schema.define(MapSchema({bar: "1"}));
-    tt.is(schema.options.definition.type, 'map');
+    const definition = MapSchema({bar: "1"});
+    schema.set(definition);
+    tt.is(schema.definition, definition);
 });
 
 
@@ -43,8 +44,8 @@ test('EntitySchema will not cause an infinite recursion', (tt: Object) => {
     const foo = EntitySchema('foo');
     const bar = EntitySchema('bar');
 
-    foo.define(MapSchema({bar}));
-    bar.define(MapSchema({foo}));
+    foo.set(MapSchema({bar}));
+    bar.set(MapSchema({foo}));
 
     const entities = fromJS({
         bar: {"1": {id: "1", foo: "1"}},

--- a/packages/enty/src/__tests__/ListSchema-test.js
+++ b/packages/enty/src/__tests__/ListSchema-test.js
@@ -5,7 +5,7 @@ import ListSchema from '../ListSchema';
 import MapSchema from '../MapSchema';
 import {fromJS} from 'immutable';
 
-const foo = EntitySchema('foo').define(MapSchema());
+const foo = EntitySchema('foo').set(MapSchema());
 
 test('ListSchema can normalize arrays', (tt: *) => {
     const schema = ListSchema(foo);
@@ -84,4 +84,30 @@ test('ListSchema will not mutate input objects', (tt: *) => {
     tt.deepEqual(arrayTest, [{id: "1"}]);
 });
 
+//
+// Setters and Getters
+//
 
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
+    const schema = ListSchema();
+    t.is(schema.set(foo), schema);
+    t.is(schema.get(), foo);
+    t.is(schema.update(() => schema.definition), schema);
+});
+
+test('set will replace the definition at a key', (t: *) => {
+    const schema = ListSchema();
+    schema.set(foo);
+    t.is(schema.definition, foo);
+});
+
+test('get will return the definition at a key', (t: *) => {
+    const schema = ListSchema(foo);
+    t.is(schema.get(), foo);
+});
+
+test('update will replace the whole definition via an updater function', (t: *) => {
+    const schema = ListSchema(foo);
+    schema.update(() => foo);
+    t.is(schema.definition, foo);
+});

--- a/packages/enty/src/__tests__/MapSchema-test.js
+++ b/packages/enty/src/__tests__/MapSchema-test.js
@@ -4,8 +4,8 @@ import EntitySchema from '../EntitySchema';
 import MapSchema from '../MapSchema';
 import {fromJS, Map} from 'immutable';
 
-var foo = EntitySchema('foo').define(MapSchema());
-var bar = EntitySchema('bar').define(MapSchema());
+var foo = EntitySchema('foo').set(MapSchema());
+var bar = EntitySchema('bar').set(MapSchema());
 
 test('MapSchema can normalize objects', (tt: *) => {
     const schema = MapSchema({foo});
@@ -113,20 +113,6 @@ test('MapSchema will pass any deleted keys to options.denormalizeFilter', (tt: *
     schema.denormalize({result: Map({foo: "1"}), entities});
 });
 
-
-test('MapSchema.merge() will perform a shallow merge of options and definition', (tt: *) => {
-    const denormalizeFilter = () => true;
-    const aa = MapSchema({foo});
-    const bb = MapSchema({bar}, {denormalizeFilter});
-    const merged = aa.merge(bb);
-
-
-    tt.is(merged.definition.foo.name, 'foo');
-    tt.is(merged.definition.bar.name, 'bar');
-    tt.is(merged.options.denormalizeFilter, denormalizeFilter);
-});
-
-
 test('MapSchema will not mutate input objects', (tt: *) => {
     const schema = MapSchema({foo});
     const objectTest = {foo: {id: "1"}};
@@ -138,3 +124,35 @@ test('MapSchema will not mutate input objects', (tt: *) => {
 });
 
 
+//
+// Getters and Setters
+//
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
+    const schema = MapSchema({foo});
+    t.is(schema.set('bar', bar), schema);
+    t.is(schema.get('foo'), foo);
+    t.is(schema.update(() => schema.definition), schema);
+});
+
+test('set will replace the definition at a key', (t: *) => {
+    const schema = MapSchema({foo});
+    schema.set('bar', bar);
+    t.is(schema.definition.bar, bar);
+});
+
+test('get will return the definition at a key', (t: *) => {
+    const schema = MapSchema({foo});
+    t.is(schema.get('foo'), foo);
+});
+
+test('update will replace the definition at a key via an updater function', (t: *) => {
+    const schema = MapSchema({foo});
+    schema.update('foo', () => bar);
+    t.is(schema.definition.foo, bar);
+});
+
+test('update will replace the whole definition via an updater function', (t: *) => {
+    const schema = MapSchema({foo});
+    schema.update(() => ({bar}));
+    t.is(schema.definition.bar, bar);
+});

--- a/packages/enty/src/__tests__/ObjectSchema-test.js
+++ b/packages/enty/src/__tests__/ObjectSchema-test.js
@@ -3,8 +3,8 @@ import test from 'ava';
 import ObjectSchema from '../ObjectSchema';
 import EntitySchema from '../EntitySchema';
 
-var foo = EntitySchema('foo').define(ObjectSchema());
-var bar = EntitySchema('bar').define(ObjectSchema());
+var foo = EntitySchema('foo').set(ObjectSchema());
+var bar = EntitySchema('bar').set(ObjectSchema());
 
 test('ObjectSchema can normalize objects', (tt: *) => {
     const schema = ObjectSchema({foo});
@@ -113,19 +113,6 @@ test('ObjectSchema will pass any deleted keys to options.denormalizeFilter', (tt
 });
 
 
-test('ObjectSchema.merge() will perform a shallow merge of options and definition', (tt: *) => {
-    const denormalizeFilter = () => true;
-    const aa = ObjectSchema({foo});
-    const bb = ObjectSchema({bar}, {denormalizeFilter});
-    const merged = aa.merge(bb);
-
-
-    tt.is(merged.definition.foo.name, 'foo');
-    tt.is(merged.definition.bar.name, 'bar');
-    tt.is(merged.options.denormalizeFilter, denormalizeFilter);
-});
-
-
 test('ObjectSchema will not mutate input objects', (tt: *) => {
     const schema = ObjectSchema({foo});
     const objectTest = {foo: {id: "1"}};
@@ -137,3 +124,33 @@ test('ObjectSchema will not mutate input objects', (tt: *) => {
 });
 
 
+
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
+    const schema = ObjectSchema({foo});
+    t.is(schema.set('bar', bar), schema);
+    t.is(schema.get('foo'), foo);
+    t.is(schema.update(() => schema.definition), schema);
+});
+
+test('ObjectSchema.set will replace the definition at a key', (t: *) => {
+    const schema = ObjectSchema({foo});
+    schema.set('bar', bar);
+    t.is(schema.definition.bar, bar);
+});
+
+test('ObjectSchema.get will return the definition at a key', (t: *) => {
+    const schema = ObjectSchema({foo});
+    t.is(schema.get('foo'), foo);
+});
+
+test('ObjectSchema.update will replace the definition at a key via an updater function', (t: *) => {
+    const schema = ObjectSchema({foo});
+    schema.update('foo', () => bar);
+    t.is(schema.definition.foo, bar);
+});
+
+test('ObjectSchema.update will replace the whole definition via an updater function', (t: *) => {
+    const schema = ObjectSchema({foo});
+    schema.update(() => ({bar}));
+    t.is(schema.definition.bar, bar);
+});

--- a/packages/enty/src/__tests__/ValueSchema-test.js
+++ b/packages/enty/src/__tests__/ValueSchema-test.js
@@ -15,12 +15,12 @@ const fooValues = MapSchema({
 
 
 
-test('ValueSchema.denormalize is almost the inverse of ValueSchema.normalize', (tt: *) => {
+test('denormalize is almost the inverse of normalize', (tt: *) => {
     const data = {foo: '1'};
     tt.deepEqual(data.foo, fooValues.denormalize(fooValues.normalize(data)).toJS().foo.id);
 });
 
-test('ValueSchema.normalize', (tt: *) => {
+test('normalize', (tt: *) => {
     const data = Map({id: '1'});
     const entities = {
         foo: {
@@ -31,7 +31,7 @@ test('ValueSchema.normalize', (tt: *) => {
     tt.true(data.equals(ValueSchema(foo).normalize('1', undefined).entities.foo['1']));
 });
 
-test('ValueSchema.denormalize', (tt: *) => {
+test('denormalize', (tt: *) => {
     const data = Map({id: '1'});
     const entities = {
         foo: {
@@ -43,10 +43,29 @@ test('ValueSchema.denormalize', (tt: *) => {
 });
 
 
-test('ValueSchema can set definition through the `define` method', (tt: *) => {
+//
+// Getters and Setters
+//
+test('set, get & update dont mutate the schema while still returning it', (t: *) => {
     const schema = ValueSchema();
-    schema.define(foo);
-
-    tt.is(schema.options.definition.name, 'foo');
+    t.is(schema.set(foo), schema);
+    t.is(schema.get(), foo);
+    t.is(schema.update(() => schema.definition), schema);
 });
 
+test('set will replace the definition at a key', (t: *) => {
+    const schema = ValueSchema();
+    schema.set(foo);
+    t.is(schema.definition, foo);
+});
+
+test('get will return the definition at a key', (t: *) => {
+    const schema = ValueSchema(foo);
+    t.is(schema.get(), foo);
+});
+
+test('update will replace the whole definition via an updater function', (t: *) => {
+    const schema = ValueSchema(foo);
+    schema.update(() => foo);
+    t.is(schema.definition, foo);
+});

--- a/packages/enty/src/abstract/Child.js
+++ b/packages/enty/src/abstract/Child.js
@@ -2,6 +2,10 @@
 import type {ChildDefinition} from '../util/definitions';
 import NullSchema from '../NullSchema';
 
+/**
+ * Child
+ * @implements {NullSchema}
+ */
 export default class Child extends NullSchema {
     definition: ChildDefinition;
 
@@ -10,15 +14,24 @@ export default class Child extends NullSchema {
         this.definition = definition;
     }
 
+    /**
+     * Child get
+     */
     get(): ChildDefinition {
         return this.definition;
     }
 
+    /**
+     * Child set
+     */
     set(value: ChildDefinition): Child {
         this.definition = value;
         return this;
     }
 
+    /**
+     * Child update
+     */
     update(updater: Function): Child {
         this.definition = updater(this.definition);
         return this;

--- a/packages/enty/src/abstract/Child.js
+++ b/packages/enty/src/abstract/Child.js
@@ -1,0 +1,26 @@
+// @flow
+import type {ChildDefinition} from '../util/definitions';
+import NullSchema from '../NullSchema';
+
+export default class Child extends NullSchema {
+    definition: ChildDefinition;
+
+    constructor(definition: ChildDefinition) {
+        super();
+        this.definition = definition;
+    }
+
+    get(): ChildDefinition {
+        return this.definition;
+    }
+
+    set(value: ChildDefinition): Child {
+        this.definition = value;
+        return this;
+    }
+
+    update(updater: Function): Child {
+        this.definition = updater(this.definition);
+        return this;
+    }
+}

--- a/packages/enty/src/abstract/Keyed.js
+++ b/packages/enty/src/abstract/Keyed.js
@@ -1,0 +1,35 @@
+// @flow
+import type {KeyedDefinition} from '../util/definitions';
+import type {ChildDefinition} from '../util/definitions';
+import NullSchema from '../NullSchema';
+
+export default class Keyed extends NullSchema {
+    definition: KeyedDefinition;
+
+    constructor(definition: KeyedDefinition) {
+        super();
+        this.definition = definition;
+    }
+
+    get(key: string): ChildDefinition {
+        return this.definition[key];
+    }
+
+    set(key: string, value: *): Keyed {
+        this.definition[key] = value;
+        return this;
+    }
+
+    update(key: string|Function, updater?: Function): Keyed {
+        if(typeof key ==='function') {
+            this.definition = key(this.definition);
+            return this;
+        }
+
+        if(typeof updater === 'function') {
+            return this.set(key, updater(this.get(key)));
+        }
+
+        throw 'updater parameter must be a function';
+    }
+}

--- a/packages/enty/src/util/definitions.js
+++ b/packages/enty/src/util/definitions.js
@@ -11,3 +11,45 @@ export type DenormalizeState = {
     entities: Object,
     result: any
 };
+
+export type KeyedDefinition = {
+    [string]: Schema<*>
+};
+
+export type ChildDefinition = Schema<*>;
+
+
+
+export type Structure = {
+    constructor: Function,
+    denormalizeFilter: Function,
+    merge: Function
+};
+
+export type Entity = {
+    idAttribute: Function,
+    name: string
+};
+
+
+export type StructureInput = {
+    definition?: ChildDefinition|KeyedDefinition,
+    constructor?: Function,
+    denormalizeFilter?: Function,
+    merge?: Function
+};
+
+export type EntityInput = {
+    definition?: Schema<Structure>,
+    name?: string,
+    idAttribute?: Function
+};
+
+
+export interface Schema<Options> {
+    normalize(data: *, entities: Object): NormalizeState,
+    denormalize(denormalizeState: DenormalizeState, path: Array<*>): any,
+    options: Options,
+    definition: *,
+    type?: string
+}

--- a/packages/react-enty/README.md
+++ b/packages/react-enty/README.md
@@ -48,7 +48,7 @@ import {
 var user = EntitySchema('user');
 var userList = ListSchema(user);
 
-user.define(MapSchema({
+user.set(MapSchema({
     friendList: userList
 }))
 

--- a/packages/react-enty/src/__tests__/EntitySelector-test.js
+++ b/packages/react-enty/src/__tests__/EntitySelector-test.js
@@ -11,7 +11,7 @@ import {
 } from '../EntitySelector';
 
 function constructState(): Object {
-    var foo = EntitySchema('foo').define(MapSchema());
+    var foo = EntitySchema('foo').set(MapSchema());
     var fooList = ListSchema(foo);
     var schema = MapSchema({
         fooList: ListSchema(foo),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,7 +1706,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@3.5.1, bluebird@^3.0.0, bluebird@^3.0.5, bluebird@^3.3.4, bluebird@^3.5.0, bluebird@^3.5.1:
+bluebird@3.5.1, bluebird@^3.0.0, bluebird@^3.0.5, bluebird@^3.3.4, bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -4531,7 +4531,7 @@ gatsby-1-config-css-modules@^1.0.10:
   dependencies:
     babel-runtime "^6.26.0"
 
-gatsby-cli@^1.1.23, gatsby-cli@^1.1.45:
+gatsby-cli@^1.1.45:
   version "1.1.45"
   resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-1.1.45.tgz#d68f780bc861130c9afe7dae7cd5bdb665b0f05a"
   dependencies:
@@ -4569,14 +4569,6 @@ gatsby-module-loader@^1.0.11:
   dependencies:
     babel-runtime "^6.26.0"
     loader-utils "^0.2.16"
-
-gatsby-plugin-github-pages@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-github-pages/-/gatsby-plugin-github-pages-1.0.1.tgz#64bc5413de7a8e3bdcc59f5fdd019690d2b75535"
-  dependencies:
-    bluebird "^3.5.1"
-    gatsby-cli "^1.1.23"
-    gh-pages "^1.1.0"
 
 gatsby-plugin-react-helmet@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
This allows for set/update/get methods for accessing and mutating
schema definitions.

DEPRECATED: schema.define(). Now Schema.set