### PR TITLE
BREAKING CHANGE: dont reconstruct entities

### DIFF
--- a/packages/enty/src/EntitySchema.js
+++ b/packages/enty/src/EntitySchema.js
@@ -76,12 +76,12 @@ export class EntitySchema extends Child implements Schema<Entity> {
         // list this schema as one that has been used
         schemas[name] = this;
 
+        result = definition.options.constructor(result);
 
-        if(previousEntity) {
-            result = definition.options.merge(previousEntity, result);
-        }
-
-        entities[name][id] = definition.options.constructor(result);
+        entities[name][id] = previousEntity
+            ? definition.options.merge(previousEntity, result)
+            : result
+        ;
 
         return {
             entities,


### PR DESCRIPTION
Previously the merged entities were being reconstructed
before being stored.

Now they are constructed once and then either merged and stored
or just stored straight away.