### PR TITLE
Feature/keyed schema perf

### DIFF
--- a/packages/enty/src/MapSchema.js
+++ b/packages/enty/src/MapSchema.js
@@ -67,7 +67,7 @@ export class MapSchema extends Keyed implements Schema<Structure> {
         const {definition, options} = this;
         let deletedKeys = [];
 
-        if(result == null || path.indexOf(this) !== -1) {
+        if(result == null) {
             return result;
         }
 
@@ -81,6 +81,9 @@ export class MapSchema extends Keyed implements Schema<Structure> {
         return pipeWith(
             result,
             (item: Map<any, any>): Map<any, any> => {
+                if(path.indexOf(this) !== -1) {
+                    return item;
+                }
                 return keys
                     .reduce((newItem: any, key: string): Map<any, any> => {
                         if(definition[key]) {

--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -65,7 +65,7 @@ export class ObjectSchema extends Keyed implements Schema<Structure> {
         const {definition, options} = this;
         let deletedKeys = [];
 
-        if(result == null || path.indexOf(this) !== -1) {
+        if(result == null) {
             return result;
         }
 
@@ -79,6 +79,9 @@ export class ObjectSchema extends Keyed implements Schema<Structure> {
         return pipeWith(
             result,
             (item: Object): Object => {
+                if(path.indexOf(this) !== -1) {
+                    return item;
+                }
                 return keys
                     .reduce((newItem: Object, key: string): Object => {
                         if(definition[key]) {

--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -1,4 +1,5 @@
 // @flow
+import clone from 'unmutable/lib/clone';
 import pipeWith from 'unmutable/lib/util/pipeWith';
 import {DELETED_ENTITY, type DeletedEntity} from './util/SchemaConstant';
 import Keyed from './abstract/Keyed';
@@ -78,6 +79,7 @@ export class ObjectSchema extends Keyed implements Schema<Structure> {
 
         return pipeWith(
             result,
+            clone(),
             (item: Object): Object => {
                 if(path.indexOf(this) !== -1) {
                     return item;

--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -1,5 +1,5 @@
 // @flow
-import {IdentityFactory as Identity} from 'fronads/lib/Identity';
+import pipeWith from 'unmutable/lib/util/pipeWith';
 import {DELETED_ENTITY, type DeletedEntity} from './util/SchemaConstant';
 import Keyed from './abstract/Keyed';
 import type {NormalizeState} from './util/definitions';
@@ -65,7 +65,7 @@ export class ObjectSchema extends Keyed implements Schema<Structure> {
         const {definition, options} = this;
         let deletedKeys = [];
 
-        if(result == null) {
+        if(result == null || path.indexOf(this) !== -1) {
             return result;
         }
 
@@ -73,38 +73,35 @@ export class ObjectSchema extends Keyed implements Schema<Structure> {
         // if they have a corresponding schema. Otherwise return the plain value.
         // Then filter out deleted keys, keeping track of ones deleted
         // Then Pump the filtered object through `denormalizeFilter`
-        return Identity(result)
-            .map((item: Object): Object => {
-                return Object.entries(item)
-                    .reduce((newItem: Object, [key]: *): Object => {
-                        var value = newItem[key];
-                        var newValue;
 
-                        if(path.indexOf(this) !== -1) {
-                            newValue = value;
-                        } else if(definition[key]) {
-                            newValue = definition[key].denormalize({result: value, entities}, path.concat(this));
-                        } else {
-                            newValue = value;
+        let keys: string[] = Object.keys(result);
+
+        return pipeWith(
+            result,
+            (item: Object): Object => {
+                return keys
+                    .reduce((newItem: Object, key: string): Object => {
+                        if(definition[key]) {
+                            let result = newItem[key];
+                            newItem[key] = definition[key].denormalize({result, entities}, path.concat(this));
                         }
-
-                        newItem[key] = newValue;
                         return newItem;
                     }, item);
-            })
-            .map((item: any): any => {
-                return Object.entries(item)
-                    .filter(([key]) => item[key] === DELETED_ENTITY)
-                    .reduce((newItem: Object, [deleteKey]: *): Object => {
-                        deletedKeys.push(deleteKey);
-                        delete newItem[deleteKey];
+            },
+            (item: any): any => {
+                return keys
+                    .reduce((newItem: Object, deleteKey: string): Object => {
+                        if(item[deleteKey] === DELETED_ENTITY) {
+                            deletedKeys.push(deleteKey);
+                            delete newItem[deleteKey];
+                        }
                         return newItem;
                     }, item);
-            })
-            .map((item: Object): Object|DeletedEntity => {
+            },
+            (item: Object): Object|DeletedEntity => {
                 return options.denormalizeFilter(item, deletedKeys) ? item : DELETED_ENTITY;
-            })
-            .value();
+            }
+        );
     }
 }
 

--- a/packages/enty/src/__test__/ObjectSchema-test.js
+++ b/packages/enty/src/__test__/ObjectSchema-test.js
@@ -85,6 +85,24 @@ test('ObjectSchema will filter out DELETED_ENTITY keys', () => {
     expect(schema.denormalize({result: {foo: "1"}, entities})).toEqual({});
 });
 
+test('ObjectSchema can denormalize objects without mutating', () => {
+    const schema = ObjectSchema({foo});
+
+    const result = {foo: "1"};
+    const originalResult = {...result};
+
+    const entities = {
+        foo: {
+            "1": {id: "1"}
+        }
+    };
+
+    schema.denormalize({result, entities});
+
+    expect(result).toEqual(originalResult);
+});
+
+
 test('ObjectSchema will pass any deleted keys to options.denormalizeFilter', () => {
     const schema = ObjectSchema({foo}, {
         denormalizeFilter: (item, deletedKeys) => expect(deletedKeys).toEqual(['foo'])


### PR DESCRIPTION
- Improve objectschema performance, now runs in ~66% of the time :D
  - Majority of the first reduce was setting the same data onto itself
  - Filter in second part was much slower than iffing inside the second reduce
  - Moved the cyclical data structure check out of the reduce
  - Used `pipeWith` instead of `Identity` monad - only tiny increase here
- Improve mapschema performance, now runs in ~47% of the time :D
  - Used `[...item.keys()]` rather than relying on `item.keySeq()`
  - Majority of the first reduce was setting the same data onto itself
  - Filter in second part was much slower than iffing inside the second reduce
  - Moved the cyclical data structure check out of the reduce
- Fix bug where objectschema would mutate on denormalize 