### PR TITLE
feat: unflatten api, add EntityProvider, move redux to deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ export default withData(User);
 1. **Props Change / OnMutate Triggered**  
 The Enty data flow begins when either a QueryHocked components props change or a MutationHocked component fires its onMutate callback. When this happens the corresponding promise creator in the API is fired. 
 
-2. **Data Request / Recieve**  
+2. **Data Request / Receive**  
 The data request actions is triggered and the corresponding queryRequestState becomes a FetchingState. If the promise rejects the Error action is triggered, the requestState becomes an error and the flow finishes. 
 If the promise resolves the receive action is triggered, the requestState becomes a SuccessState. 
 

--- a/packages/enty/README.md
+++ b/packages/enty/README.md
@@ -129,7 +129,7 @@ export default withData(User);
 1. **Props Change / OnMutate Triggered**  
 The Enty data flow begins when either a QueryHocked components props change or a MutationHocked component fires its onMutate callback. When this happens the corresponding promise creator in the API is fired. 
 
-2. **Data Request / Recieve**  
+2. **Data Request / Receive**  
 The data request actions is triggered and the corresponding queryRequestState becomes a FetchingState. If the promise rejects the Error action is triggered, the requestState becomes an error and the flow finishes. 
 If the promise resolves the receive action is triggered, the requestState becomes a SuccessState. 
 

--- a/packages/react-enty/README.md
+++ b/packages/react-enty/README.md
@@ -129,7 +129,7 @@ export default withData(User);
 1. **Props Change / OnMutate Triggered**  
 The Enty data flow begins when either a QueryHocked components props change or a MutationHocked component fires its onMutate callback. When this happens the corresponding promise creator in the API is fired. 
 
-2. **Data Request / Recieve**  
+2. **Data Request / Receive**  
 The data request actions is triggered and the corresponding queryRequestState becomes a FetchingState. If the promise rejects the Error action is triggered, the requestState becomes an error and the flow finishes. 
 If the promise resolves the receive action is triggered, the requestState becomes a SuccessState. 
 

--- a/packages/react-enty/package.json
+++ b/packages/react-enty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-enty",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "React bindings for managing state with enty schemas",
   "main": "lib/index.js",
   "license": "UNLICENSED",

--- a/packages/react-enty/package.json
+++ b/packages/react-enty/package.json
@@ -21,14 +21,12 @@
     "build": "rm -rf lib && NODE_ENV=production babel src --out-dir lib --ignore **/*-test.js",
     "watch": "yarn build -w"
   },
-  "peerDependencies": {
-    "react-redux": ">=4",
-    "redux": "^3.6.0"
-  },
   "dependencies": {
     "enty": "^0.48.1",
     "fronads": "^0.17.0",
     "immutable": "^3.8.1",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0",
     "redux-actions": "^2.0.1",
     "redux-thunk": "^2.1.0",
     "stampy": "^0.43.2",

--- a/packages/react-enty/src/EntityApi.js
+++ b/packages/react-enty/src/EntityApi.js
@@ -47,7 +47,7 @@ function visitActionMap(branch: *, visitor: Function, path: string[] = [], state
 // to select the next denormalized state and return that to the promise chain.
 // This means request functions can be chained, yet still contain the latests state.
 //
-export function createRequestAction(fetchAction: string, recieveAction: string, errorAction: string, sideEffect: SideEffect): Function {
+export function createRequestAction(fetchAction: string, receiveAction: string, errorAction: string, sideEffect: SideEffect): Function {
     function action(aa: string): Function {
         return createAction(aa, (payload) => payload, (payload, meta) => meta);
     }
@@ -66,8 +66,8 @@ export function createRequestAction(fetchAction: string, recieveAction: string, 
         dispatch(action(fetchAction)(null, actionMeta(fetchAction)));
         return sideEffect(requestPayload, sideEffectMeta).then(
             (data: any): * => {
-                dispatch(action(recieveAction)(data, actionMeta(recieveAction)));
-                return selectEntityByResult(getState(), actionMeta(recieveAction).resultKey);
+                dispatch(action(receiveAction)(data, actionMeta(receiveAction)));
+                return selectEntityByResult(getState(), actionMeta(receiveAction).resultKey);
             },
             (error: any): * => {
                 dispatch(action(errorAction)(error, actionMeta(errorAction)));
@@ -81,7 +81,7 @@ export function createRequestAction(fetchAction: string, recieveAction: string, 
 // @DEPRECATED
 // This is only used by the mutation and query hocks
 // RequestHoc has more powerful composition and so the actions dont need to be chained
-export function createAllRequestAction(fetchAction: string, recieveAction: string, errorAction: string, sideEffectList: Array<SideEffect>): Function {
+export function createAllRequestAction(fetchAction: string, receiveAction: string, errorAction: string, sideEffectList: Array<SideEffect>): Function {
     function sideEffect(requestPayload: *, meta: Object): Promise<*> {
         return Promise
             // call all sideeffects
@@ -90,7 +90,7 @@ export function createAllRequestAction(fetchAction: string, recieveAction: strin
             .then(payloads => payloads.reduce((out, payload) => Object.assign(out, payload), {}))
         ;
     }
-    return createRequestAction(fetchAction, recieveAction, errorAction, sideEffect);
+    return createRequestAction(fetchAction, receiveAction, errorAction, sideEffect);
 }
 
 

--- a/packages/react-enty/src/EntityMutationHockFactory.js
+++ b/packages/react-enty/src/EntityMutationHockFactory.js
@@ -1,12 +1,14 @@
 //@flow
+import type {HockOptions} from './util/definitions';
+import type {HockOptionsInput} from './util/definitions';
+
 import RequestStateSelector from './RequestStateSelector';
 import {selectEntityByResult} from './EntitySelector';
 import DistinctMemo from './util/DistinctMemo';
 import Connect from './util/Connect';
 import {fromJS} from 'immutable';
 import React, {type Element} from 'react';
-import type {HockOptions} from './util/definitions';
-import type {HockOptionsInput} from './util/definitions';
+import Deprecated from './util/Deprecated';
 
 /**
  * EntityMutationHockFactory
@@ -53,7 +55,7 @@ export default function EntityMutationHockFactory(actionCreator: Function, hockO
      * export default withMutation(User);
      */
     function EntityMutationHock(payloadCreator: Function = aa => aa, optionsOverride: HockOptionsInput): Function {
-        console.warn('DEPRECATED: EntityMutationHock has been deprecated in favor of much improved RequestHock. Check the docs for usage instructions.');
+        Deprecated('EntityMutationHock has been deprecated in favor of much improved RequestHock. Check the docs for usage instructions.');
 
         const distinctSuccessMap = new DistinctMemo((value, data) => value.successMap(() => data));
 

--- a/packages/react-enty/src/EntityProviderFactory.jsx
+++ b/packages/react-enty/src/EntityProviderFactory.jsx
@@ -1,0 +1,16 @@
+//@flow
+import type {Node} from 'react';
+import React from 'react';
+import {createProvider} from 'react-redux';
+
+type Config = {
+    store: *,
+    storeKey: string
+};
+
+export default function EntityProviderFactory({store, storeKey}: Config): Function {
+    const Provider = createProvider(storeKey);
+    return function EntityProvider(props: *): Node {
+        return <Provider store={store} children={props.children} />;
+    };
+}

--- a/packages/react-enty/src/EntityProviderFactory.jsx
+++ b/packages/react-enty/src/EntityProviderFactory.jsx
@@ -10,7 +10,7 @@ type Config = {
 
 export default function EntityProviderFactory({store, storeKey}: Config): Function {
     const Provider = createProvider(storeKey);
-    return function EntityProvider(props: *): Node {
-        return <Provider store={store} children={props.children} />;
+    return () => (Component) => function EntityProvider(props: *): Node {
+        return <Provider store={store} children={<Component {...props}/>} />;
     };
 }

--- a/packages/react-enty/src/EntityQueryHockFactory.js
+++ b/packages/react-enty/src/EntityQueryHockFactory.js
@@ -1,16 +1,17 @@
 //@flow
-import PropChangeHock from 'stampy/lib/hock/PropChangeHock';
-
-import RequestStateSelector from './RequestStateSelector';
-import {selectEntityByResult} from './EntitySelector';
-import DistinctMemo from './util/DistinctMemo';
-import Connect from './util/Connect';
-import {fromJS} from 'immutable';
 import type {ComponentType} from 'react';
 import type {HockApplier} from './util/definitions';
 import type {HockOptionsInput} from './util/definitions';
 import type {HockOptions} from './util/definitions';
 import type {Hock} from './util/definitions';
+
+import PropChangeHock from 'stampy/lib/hock/PropChangeHock';
+import {fromJS} from 'immutable';
+import RequestStateSelector from './RequestStateSelector';
+import {selectEntityByResult} from './EntitySelector';
+import DistinctMemo from './util/DistinctMemo';
+import Connect from './util/Connect';
+import Deprecated from './util/Deprecated';
 
 
 /**
@@ -33,7 +34,7 @@ function EntityQueryHockFactory(actionCreator: Function, hockOptions?: HockOptio
      * @kind function
      */
     function EntityQueryHock(queryCreator: Function = () => null, optionsOverride: HockOptionsInput|Array<string>): HockApplier {
-        console.warn('DEPRECATED: EntityQueryHock has been deprecated in favor of much improved RequestHock. Check the docs for usage instructions.');
+        Deprecated('EntityQueryHock has been deprecated in favor of much improved RequestHock. Check the docs for usage instructions.');
         function parseOptions(options: HockOptionsInput|Array<string>): Object {
             if(Array.isArray(options)) {
                 return {propChangeKeys: optionsOverride};

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -1,4 +1,7 @@
 //@flow
+import type {Schema} from 'enty/lib/util/definitions';
+import type {Structure} from 'enty/lib/util/definitions';
+
 import {Map} from 'immutable';
 import updateIn from 'unmutable/lib/updateIn';
 import pipeWith from 'unmutable/lib/util/pipeWith';
@@ -29,7 +32,7 @@ import Logger from './Logger';
  *     })
  * });
  */
-export default function EntityReducerFactory(config: {schema: Schema}): Function {
+export default function EntityReducerFactory(config: {schema: Schema<Structure>}): Function {
     const {schema} = config;
 
     const initialState = Map({

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -29,13 +29,11 @@ import Logger from './Logger';
  *     })
  * });
  */
-export default function EntityReducerFactory(config: Object): Function {
-    const {
-        schemaMap
-    } = config;
+export default function EntityReducerFactory(config: {schema: Schema}): Function {
+    const {schema} = config;
 
     const initialState = Map({
-        _baseSchema: Map(schemaMap),
+        _baseSchema: schema,
         _schemas: Map(),
         _result: Map(),
         _error: Map(),
@@ -51,13 +49,11 @@ export default function EntityReducerFactory(config: Object): Function {
 
     // Return our constructed reducer
     return function EntityReducer(state: Map<any, any> = initialState, {type, payload, meta}: Object): Map<any, any> {
-        // debugger;
 
         Logger.info(`\n\nEntity reducer:`);
 
 
         const {
-            schema = schemaMap[type],
             resultKey = type,
             resultResetOnFetch
         } = Object.assign({}, defaultMeta, meta);
@@ -107,7 +103,7 @@ export default function EntityReducerFactory(config: Object): Function {
 
             if(schema && payload) {
                 let previousEntities = state
-                    .map(ii => ii.toObject())
+                    .map(ii => ii.toObject ? ii.toObject() : ii)
                     .delete('_actionSchema')
                     .delete('_result')
                     .delete('_requestState')
@@ -121,6 +117,7 @@ export default function EntityReducerFactory(config: Object): Function {
                 return state
                     // set results
                     .update(state => state.merge(Map(entities).map(ii => Map(ii))))
+                    .set('_baseSchema', schema)
                     .setIn(['_result', resultKey], result)
                     .updateIn(['_schemas'], (previous) => Map(schemas).merge(previous))
                     .update((state: *): * => {

--- a/packages/react-enty/src/EntitySelector.js
+++ b/packages/react-enty/src/EntitySelector.js
@@ -16,13 +16,10 @@ import KeyedMemo from './util/KeyedMemo';
 const DenormalizeCache = new KeyedMemo();
 
 export function selectEntityByResult(state: Object, resultKey: string, options: Object = {}): * {
-    const {schemaKey = 'ENTITY_RECEIVE'} = options;
     const {stateKey = 'entity'} = options;
-
     const entities = state[stateKey];
-    const schema = getIn(['_baseSchema', schemaKey])(entities);
+    const schema = getIn(['_baseSchema'])(entities);
     const normalizeCount = getIn(['_stats', 'normalizeCount'])(entities);
-
 
     if(!schema) {
         return;

--- a/packages/react-enty/src/EntityStoreFactory.jsx
+++ b/packages/react-enty/src/EntityStoreFactory.jsx
@@ -2,8 +2,12 @@
 import thunk from 'redux-thunk';
 import {combineReducers, compose, createStore, applyMiddleware} from 'redux';
 
-// create and export the store
-export default function EntityStoreFactory(reducer: any): any {
+type Config = {
+    reducer: Function
+};
+
+export default function EntityStoreFactory(config: Config): any {
+    const {reducer} = config;
     // create middleware
     var middleware = applyMiddleware(thunk);
 

--- a/packages/react-enty/src/MultiMutationHockFactory.js
+++ b/packages/react-enty/src/MultiMutationHockFactory.js
@@ -1,8 +1,10 @@
 //@flow
-import EntityMutationHockFactory from './EntityMutationHockFactory';
-import {createAllRequestAction} from './EntityApi';
 import type {HockOptionsInput} from './util/definitions';
 import type {SideEffect} from './util/definitions';
+
+import EntityMutationHockFactory from './EntityMutationHockFactory';
+import {createAllRequestAction} from './EntityApi';
+import Deprecated from './util/Deprecated';
 
 /**
  * MultiMutationHockFactory
@@ -13,7 +15,7 @@ function MultiMutationHockFactory(sideEffectList: Array<SideEffect>, hockOptions
     const RECEIVE = `${actionPrefix}_RECEIVE`;
     const ERROR = `${actionPrefix}_ERROR`;
 
-    console.warn('DEPRECATED: MultiMutationHockFactory has been deprecated in favor of much improved MultiRequestHock. Check the docs for usage instructions.');
+    Deprecated('MultiMutationHockFactory has been deprecated in favor of much improved MultiRequestHock. Check the docs for usage instructions.');
     return EntityMutationHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), hockOptions);
 }
 

--- a/packages/react-enty/src/MultiQueryHockFactory.js
+++ b/packages/react-enty/src/MultiQueryHockFactory.js
@@ -1,9 +1,10 @@
 //@flow
-import EntityQueryHockFactory from './EntityQueryHockFactory';
-import {createAllRequestAction} from './EntityApi';
 import type {HockOptionsInput} from './util/definitions';
 import type {SideEffect} from './util/definitions';
 
+import EntityQueryHockFactory from './EntityQueryHockFactory';
+import {createAllRequestAction} from './EntityApi';
+import Deprecated from './util/Deprecated';
 
 /**
  * Lorem ipsum dolor sit amet, consectetur _adipisicing_ elit. Commodi at optio quos animi aut officia
@@ -15,7 +16,7 @@ function MultiQueryHockFactory(sideEffectList: Array<SideEffect>, hockOptions?: 
     const RECEIVE = `${actionPrefix}_RECEIVE`;
     const ERROR = `${actionPrefix}_ERROR`;
 
-    console.warn('DEPRECATED: MultiQueryHockFactory has been deprecated in favor of much improved MultiRequestHock. Check the docs for usage instructions.');
+    Deprecated('MultiQueryHockFactory has been deprecated in favor of much improved MultiRequestHock. Check the docs for usage instructions.');
     return EntityQueryHockFactory(createAllRequestAction(FETCH, RECEIVE, ERROR, sideEffectList), hockOptions);
 }
 

--- a/packages/react-enty/src/RequestHockFactory.js
+++ b/packages/react-enty/src/RequestHockFactory.js
@@ -99,6 +99,7 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
                                 .successMap(() => nextResultKey)
                                 .value();
 
+
                             return {
                                 [name]: {
                                     // @TODO rename resultKey to responseKey

--- a/packages/react-enty/src/__test__/EntityApi-test.js
+++ b/packages/react-enty/src/__test__/EntityApi-test.js
@@ -4,6 +4,7 @@ import {Map} from 'immutable';
 import EntityApi from '../EntityApi';
 import ObjectSchema from 'enty/lib/ObjectSchema';
 import {createAllRequestAction} from '../EntityApi';
+import {createRequestAction} from '../EntityApi';
 
 const RESOLVE = (aa) => Promise.resolve(aa);
 const REJECT = (aa) => Promise.reject(aa);
@@ -18,53 +19,48 @@ var actions = EntityApi(ObjectSchema({}), {
 
 const getState = () => ({
     entity: Map()
-})
+});
+const fakeAction = (sideEffect) => createRequestAction('fetch', 'recieve', 'error', sideEffect);
 
 test('createRequestActionSet', () => {
-    expect(typeof actions.foo.bar === 'function').toBe(true);
-    expect(actions.actionTypes.FOO_BAR_FETCH).toBe('FOO_BAR_FETCH');
-    expect(actions.actionTypes.FOO_BAR_RECEIVE).toBe('FOO_BAR_RECEIVE');
-    expect(actions.actionTypes.FOO_BAR_ERROR).toBe('FOO_BAR_ERROR');
+    expect(typeof actions.foo.bar.request === 'function').toBe(true);
 });
 
 
 //
 // createRequestAction
-
-// const getRequest = (side) => createRequestAction('FOO_FETCH', 'FOO_RECEIVE', 'FOO_ERROR', side);
-
 test('createRequestAction returns a function', () => {
-    expect(typeof actions.resolve()).toBe('function');
+    expect(typeof actions.resolve.request).toBe('function');
 });
 
 test('createRequestAction dispatches FETCH always', () => {
     var dispatch = sinon.spy();
-    return actions.resolve(RESOLVE)(dispatch, getState)
+    return fakeAction(RESOLVE)()(dispatch, getState)
         .then(() => {
-            expect('RESOLVE_FETCH').toBe(dispatch.firstCall.args[0].type);
+            expect(dispatch.firstCall.args[0].type).toBe('fetch');
         });
 });
 
 test('RECEIVE action resultKey defaults to RECEIVE action name', () => {
     var dispatch = sinon.spy();
-    return actions.resolve(RESOLVE)(dispatch, getState)
+    return fakeAction(RESOLVE)()(dispatch, getState)
         .then(() => {
-            expect(dispatch.secondCall.args[0].type).toBe('RESOLVE_RECEIVE');
+            expect(dispatch.secondCall.args[0].type).toBe('recieve');
         });
 });
 
 test('ERROR action resultKey defaults to ERROR action name', () => {
     var dispatch = sinon.spy();
-    return actions.reject(REJECT)(dispatch, getState)
+    return fakeAction(REJECT)()(dispatch, getState)
         .catch(_ => _)
         .then(() => {
-            expect('REJECT_ERROR').toBe(dispatch.secondCall.args[0].type);
+            expect(dispatch.secondCall.args[0].type).toBe('error');
         });
 });
 
 test('FETCH RECIEVE action will pass meta through', () => {
     var dispatch = sinon.spy();
-    return actions.resolve(RESOLVE, {foo: 'bar'})(dispatch, getState)
+    return fakeAction(RESOLVE)({}, {foo: 'bar'})(dispatch, getState)
         .then(() => {
             expect('bar').toBe(dispatch.firstCall.args[0].meta.foo);
             expect('bar').toBe(dispatch.secondCall.args[0].meta.foo);
@@ -73,7 +69,7 @@ test('FETCH RECIEVE action will pass meta through', () => {
 
 test('ERROR action will pass meta through', () => {
     var dispatch = sinon.spy();
-    return actions.reject(REJECT, {foo: 'bar'})(dispatch, getState)
+    return fakeAction(REJECT)({}, {foo: 'bar'})(dispatch, getState)
         .catch(_ => _)
         .then(() => {
             expect('bar').toBe(dispatch.secondCall.args[0].meta.foo);

--- a/packages/react-enty/src/__test__/EntityApi-test.js
+++ b/packages/react-enty/src/__test__/EntityApi-test.js
@@ -20,7 +20,7 @@ var actions = EntityApi(ObjectSchema({}), {
 const getState = () => ({
     entity: Map()
 });
-const fakeAction = (sideEffect) => createRequestAction('fetch', 'recieve', 'error', sideEffect);
+const fakeAction = (sideEffect) => createRequestAction('fetch', 'receive', 'error', sideEffect);
 
 test('createRequestActionSet', () => {
     expect(typeof actions.foo.bar.request === 'function').toBe(true);
@@ -45,7 +45,7 @@ test('RECEIVE action resultKey defaults to RECEIVE action name', () => {
     var dispatch = sinon.spy();
     return fakeAction(RESOLVE)()(dispatch, getState)
         .then(() => {
-            expect(dispatch.secondCall.args[0].type).toBe('recieve');
+            expect(dispatch.secondCall.args[0].type).toBe('receive');
         });
 });
 
@@ -58,7 +58,7 @@ test('ERROR action resultKey defaults to ERROR action name', () => {
         });
 });
 
-test('FETCH RECIEVE action will pass meta through', () => {
+test('FETCH RECEIVE action will pass meta through', () => {
     var dispatch = sinon.spy();
     return fakeAction(RESOLVE)({}, {foo: 'bar'})(dispatch, getState)
         .then(() => {

--- a/packages/react-enty/src/__test__/EntityProviderFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityProviderFactory-test.js
@@ -1,0 +1,68 @@
+// @flow
+import React from 'react';
+import EntityProviderFactory from '../EntityProviderFactory';
+import EntityApi from '../EntityApi';
+import ObjectSchema from 'enty/lib/ObjectSchema';
+import composeWith from 'unmutable/lib/util/composeWith';
+import pipe from 'unmutable/lib/util/pipe';
+
+function render(element, predicate, hocs = _ => _) {
+    return new Promise((resolve, reject) => {
+        let wrapper;
+        const component = composeWith(hocs, (props) => {
+            predicate(props, () => resolve(props, wrapper), () => reject(props, wrapper));
+            return <div/>;
+        });
+        wrapper = mount(element(component));
+    });
+}
+
+test('EntityProviderFactory returns a function', () => {
+    expect(typeof EntityProviderFactory({store: null, storeKey: 'test'})).toBe('function');
+});
+
+test('EntityProvider can store state', () => {
+    const Schema = ObjectSchema({});
+    const Api = EntityApi(Schema, {
+        foo: () => Promise.resolve({foo: 'foo!'})
+    });
+
+    return render(
+        (Component) => <Api.EntityProvider><Component/></Api.EntityProvider>,
+        (props, resolve) => props.foo.requestState.successMap(resolve),
+        Api.foo.request({name: 'foo', auto: true})
+    )
+        .then((props) => expect(props.foo.response).toEqual({foo: 'foo!'}));
+
+
+});
+
+test('Different EntityProviders can be stacked transparently', () => {
+    const SchemaA = ObjectSchema({});
+    const SchemaB = ObjectSchema({});
+    const ApiA = EntityApi(SchemaA, {
+        foo: () => Promise.resolve({foo: 'foo!'})
+    });
+    const ApiB = EntityApi(SchemaA, {
+        bar: () => Promise.resolve({bar: 'bar!'})
+    });
+
+    return render(
+        (Component) => <ApiA.EntityProvider>
+            <ApiB.EntityProvider>
+                <Component/>
+            </ApiB.EntityProvider>
+        </ApiA.EntityProvider>,
+        (props, resolve) => props.foo.requestState
+            .successFlatMap(() => props.bar.requestState)
+            .successMap(resolve),
+        pipe(
+            ApiA.foo.request({name: 'foo', auto: true}),
+            ApiB.bar.request({name: 'bar', auto: true})
+        )
+    )
+        .then((props) => {
+            expect(props.foo.response).toEqual({foo: 'foo!'});
+            expect(props.bar.response).toEqual({bar: 'bar!'});
+        })
+});

--- a/packages/react-enty/src/__test__/EntityReducerFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityReducerFactory-test.js
@@ -27,15 +27,8 @@ const schema = MapSchema({
     subreddit
 });
 
-const schemaMap = {
-    ENTITY_RECEIVE: schema,
-    TEST_RECEIVE: schema
-};
 
-const EntityReducer = EntityReducerFactory({
-    schemaMap,
-    afterNormalize: value => value
-});
+const EntityReducer = EntityReducerFactory({schema});
 
 
 // Mock data
@@ -84,7 +77,7 @@ test('EntityReducerFactory', () => {
 
     expect(is(
         EntityReducer(undefined, exampleAction).get('_baseSchema'),
-        Map(schemaMap)
+        schema
     )).toBe(true);
 
     expect(is(

--- a/packages/react-enty/src/__test__/EntitySelector-test.js
+++ b/packages/react-enty/src/__test__/EntitySelector-test.js
@@ -29,10 +29,7 @@ function constructState(): * {
             ...normalized.entities,
             _result: normalized.result,
             _schemas: normalized.schemas,
-            _baseSchema: Map({
-                ENTITY_RECEIVE: schema,
-                fooList
-            })
+            _baseSchema: schema
         })
     };
 }

--- a/packages/react-enty/src/__test__/RequestHockFactory-test.js
+++ b/packages/react-enty/src/__test__/RequestHockFactory-test.js
@@ -26,10 +26,8 @@ const STORE = {
     dispatch: (aa) => aa,
     getState: () => ({
         entity: fromJS({
-            _baseSchema: Map({
-                SCHEMA_KEY: ObjectSchema({
-                    entity: ObjectSchema({})
-                })
+            _baseSchema: ObjectSchema({
+                entity: ObjectSchema({})
             }),
             _result: {
                 foo: {
@@ -45,8 +43,7 @@ const STORE = {
 
 const hockMeta: HockMeta = {
     generateResultKey: props => `${props}-resultKey`,
-    requestActionName: 'FooAction',
-    schemaKey: 'SCHEMA_KEY'
+    requestActionName: 'FooAction'
 };
 
 const RequestHock = RequestHockFactory(resolve('foo'), hockMeta);

--- a/packages/react-enty/src/util/Deprecated.js
+++ b/packages/react-enty/src/util/Deprecated.js
@@ -1,0 +1,8 @@
+// @flow
+
+export default function Deprecated(message: string) {
+    if(process.env.NODE_ENV !== 'production') {
+        console.warn(`[Enty] DEPRECATED: ${message}`);
+    }
+}
+

--- a/taskell.md
+++ b/taskell.md
@@ -1,0 +1,9 @@
+## To Do
+
+- Move Entities to sub key
+
+## Done
+
+- Stop Flattening the api
+    > just plain traverse the api and replace each function with a hoc.
+- Create an entity provider

--- a/yarn.lock
+++ b/yarn.lock
@@ -10890,6 +10890,13 @@ redux@^3.6.0:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
 
+redux@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
+  dependencies:
+    loose-envify "^1.1.0"
+    symbol-observable "^1.2.0"
+
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
@@ -12544,7 +12551,7 @@ symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
* Unflatten API; keep the original structure provided
* Add entity provider
* Depend on redux
* BREAKING CHANGE: Remove the concept of multiple schemas
