### PR TITLE
feat: add message response get methods

### DIFF
--- a/packages/react-enty/src/data/Message.js
+++ b/packages/react-enty/src/data/Message.js
@@ -1,10 +1,13 @@
 // @flow
+import type {RequestState} from '../RequestState';
 import {EmptyState} from '../RequestState';
 import {FetchingState} from '../RequestState';
 import {RefetchingState} from '../RequestState';
 import {SuccessState} from '../RequestState';
 import {ErrorState} from '../RequestState';
-import type {RequestState} from '../RequestState';
+
+import get from 'unmutable/lib/get';
+import getIn from 'unmutable/lib/getIn';
 
 type MessageProps = {
     resultKey?: ?string,
@@ -64,30 +67,43 @@ export default class Message {
         this.requestError = props.requestError;
         this.onRequest = props.onRequest;
     }
+
+    get(key: string, notFoundValue: *): * {
+        return get(key, notFoundValue)(this.response);
+    }
+
+    getIn(path: string[], notFoundValue: *): * {
+        return getIn(path, notFoundValue)(this.response);
+    }
 }
 
-export const EmptyMessage = (rest: MessageProps) => new Message(
+
+//
+// Constructors
+//
+
+export const EmptyMessage = (rest?: MessageProps = {}) => new Message(
     rest
 );
 
-export const FetchingMessage = (rest: MessageProps) => new Message({
+export const FetchingMessage = (rest?: MessageProps = {}) => new Message({
     requestState: FetchingState(),
     ...rest
 });
 
-export const SuccessMessage = (response: *, rest: MessageProps) => new Message({
+export const SuccessMessage = (response: *, rest?: MessageProps = {}) => new Message({
     response,
     requestState: SuccessState(),
     ...rest
 });
 
-export const RefetchingMessage = (response: *, rest: MessageProps) => new Message({
+export const RefetchingMessage = (response: *, rest?: MessageProps = {}) => new Message({
     response,
     requestState: RefetchingState(),
     ...rest
 });
 
-export const ErrorMessage = (requestError: *, rest: MessageProps) => new Message({
+export const ErrorMessage = (requestError: *, rest?: MessageProps = {}) => new Message({
     requestError,
     requestState: ErrorState(),
     ...rest

--- a/packages/react-enty/src/data/__test__/Message-test.js
+++ b/packages/react-enty/src/data/__test__/Message-test.js
@@ -28,37 +28,59 @@ test('will default requestState to Empty', () => {
     expect(new Message().requestState.isEmpty).toBe(true);
 });
 
-test('EmptyMessage will create a empty message without a response', () => {
-    const message = EmptyMessage({resultKey: 'bar'});
-    expect(message.response).toBeUndefined();
-    expect(message.requestState.isEmpty).toBe(true);
-    expect(message.resultKey).toBe('bar');
+describe('Message response methods', () => {
+
+    const message = SuccessMessage({
+        foo: 'bar',
+        bar: {
+            baz: 'qux'
+        }
+    });
+
+    test('Message.get will select a value from the response', () => {
+        expect(message.get('foo')).toBe('bar');
+    });
+
+    test('Message.getIn will select a deep value from the response', () => {
+        expect(message.getIn(['bar', 'baz'])).toBe('qux');
+    });
+
 });
 
-test('FetchingMessage will create a fetching message without a response', () => {
-    const message = FetchingMessage({resultKey: 'bar'});
-    expect(message.response).toBeUndefined();
-    expect(message.requestState.isFetching).toBe(true);
-    expect(message.resultKey).toBe('bar');
+describe('Message Constructors', () => {
+    test('EmptyMessage will create a empty message without a response', () => {
+        const message = EmptyMessage({resultKey: 'bar'});
+        expect(message.response).toBeUndefined();
+        expect(message.requestState.isEmpty).toBe(true);
+        expect(message.resultKey).toBe('bar');
+    });
+
+    test('FetchingMessage will create a fetching message without a response', () => {
+        const message = FetchingMessage({resultKey: 'bar'});
+        expect(message.response).toBeUndefined();
+        expect(message.requestState.isFetching).toBe(true);
+        expect(message.resultKey).toBe('bar');
+    });
+
+    test('RefetchingMessage will create a refetching message with a response', () => {
+        const message = RefetchingMessage('foo', {resultKey: 'bar'});
+        expect(message.response).toBe('foo');
+        expect(message.requestState.isRefetching).toBe(true);
+        expect(message.resultKey).toBe('bar');
+    });
+
+    test('SuccessMessage will create a success message with a response', () => {
+        const message = SuccessMessage('foo', {resultKey: 'bar'});
+        expect(message.response).toBe('foo');
+        expect(message.requestState.isSuccess).toBe(true);
+        expect(message.resultKey).toBe('bar');
+    });
+
+    test('ErrorMessage will create a error message with requestError', () => {
+        const message = ErrorMessage('foo', {resultKey: 'bar'});
+        expect(message.requestError).toBe('foo');
+        expect(message.requestState.isError).toBe(true);
+        expect(message.resultKey).toBe('bar');
+    });
 });
 
-test('RefetchingMessage will create a refetching message with a response', () => {
-    const message = RefetchingMessage('foo', {resultKey: 'bar'});
-    expect(message.response).toBe('foo');
-    expect(message.requestState.isRefetching).toBe(true);
-    expect(message.resultKey).toBe('bar');
-});
-
-test('SuccessMessage will create a success message with a response', () => {
-    const message = SuccessMessage('foo', {resultKey: 'bar'});
-    expect(message.response).toBe('foo');
-    expect(message.requestState.isSuccess).toBe(true);
-    expect(message.resultKey).toBe('bar');
-});
-
-test('ErrorMessage will create a error message with requestError', () => {
-    const message = ErrorMessage('foo', {resultKey: 'bar'});
-    expect(message.requestError).toBe('foo');
-    expect(message.requestState.isError).toBe(true);
-    expect(message.resultKey).toBe('bar');
-});

--- a/taskell.md
+++ b/taskell.md
@@ -4,16 +4,16 @@
 - Deprecate select by type and id
 - Remove Stampy Dependency
 
-
 ## Current Release
 
 - Remove immutable from reducer
 - Check and remove result reset on fetch
 
 ## In Progress
-- Move Entities to sub key
+
 
 ## Done
 
 - Stop Flattening the api
 - Create an entity provider
+- Move Entities to sub key


### PR DESCRIPTION
Add get and getIn methods to let people have easier
and safer access to the response object.

```
const foo = props.message.response.foo;
const foo = props.message.get('foo');
const bar = props.message.response.foo.bar;
const bar = props.message.getIn(['foo', 'bar']);
```