### PR TITLE
Remove Immutable

### DIFF
--- a/packages/enty-immutable/.npmignore
+++ b/packages/enty-immutable/.npmignore
@@ -1,0 +1,2 @@
+.babelrc
+example

--- a/packages/enty-immutable/README.md
+++ b/packages/enty-immutable/README.md
@@ -1,0 +1,2 @@
+# Enty Immutable
+Enty schemas for immutable js

--- a/packages/enty-immutable/package.json
+++ b/packages/enty-immutable/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "enty-immutable",
+  "version": "0.1.0-0",
+  "description": "Enty schemas for Immutable JS",
+  "main": "lib/index.js",
+  "license": "MIT",
+  "author": "Allan Hortle",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/blueflag/enty.git"
+  },
+  "files": [
+    "lib"
+  ],
+  "bugs": {
+    "url": "https://github.com/blueflag/enty/issues"
+  },
+  "private": false,
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "rm -rf lib && NODE_ENV=production babel src --out-dir lib --ignore **/*-test.js",
+    "watch": "yarn build -w"
+  },
+  "dependencies": {
+    "immutable": "^3.8.1"
+  }
+}

--- a/packages/enty-immutable/package.json
+++ b/packages/enty-immutable/package.json
@@ -22,6 +22,7 @@
     "watch": "yarn build -w"
   },
   "dependencies": {
+    "enty": "^0.49.0-0",
     "immutable": "^3.8.1"
   }
 }

--- a/packages/enty-immutable/src/ListSchema.js
+++ b/packages/enty-immutable/src/ListSchema.js
@@ -6,6 +6,7 @@ import type {StructureInput} from 'enty';
 /**
  * An array schema that casts the data to an immutable js List
  */
+// $FlowFixMe - cant handle the fact tha classes end up as functions
 export class ListSchema extends ArraySchema {
     constructor(definition: Object, options: StructureInput = {}) {
         super(definition, options);

--- a/packages/enty-immutable/src/ListSchema.js
+++ b/packages/enty-immutable/src/ListSchema.js
@@ -1,13 +1,12 @@
 // @flow
 import {List} from 'immutable';
-import {ArraySchema} from './ArraySchema';
-import type {StructureInput} from './util/definitions';
+import {ArraySchema} from 'enty';
+import type {StructureInput} from 'enty';
 
 /**
  * An array schema that casts the data to an immutable js List
  */
 export class ListSchema extends ArraySchema {
-
     constructor(definition: Object, options: StructureInput = {}) {
         super(definition, options);
         this.options = {

--- a/packages/enty-immutable/src/MapSchema.js
+++ b/packages/enty-immutable/src/MapSchema.js
@@ -1,9 +1,9 @@
 // @flow
-import type {StructureInput} from './util/definitions';
-import type {KeyedDefinition} from './util/definitions';
+import type {StructureInput} from 'enty';
+import type {KeyedDefinition} from 'enty';
 
 import {Map} from 'immutable';
-import {ObjectSchema} from './ObjectSchema';
+import {ObjectSchema} from 'enty';
 
 /**
  * The MapSchema is a structural schema used to define relationships in objects.

--- a/packages/enty-immutable/src/MapSchema.js
+++ b/packages/enty-immutable/src/MapSchema.js
@@ -18,6 +18,7 @@ import {ObjectSchema} from 'enty';
  * @param {Object} options
  *
  */
+// $FlowFixMe - cant handle the fact tha classes end up as functions
 export class MapSchema extends ObjectSchema {
     constructor(definition: KeyedDefinition, options: StructureInput = {}) {
         super(definition, options);

--- a/packages/enty-immutable/src/__test__/ListSchema-test.js
+++ b/packages/enty-immutable/src/__test__/ListSchema-test.js
@@ -1,5 +1,5 @@
 //@flow
-import EntitySchema from 'enty';
+import {EntitySchema} from 'enty';
 import ListSchema from '../ListSchema';
 import MapSchema from '../MapSchema';
 import {fromJS} from 'immutable';

--- a/packages/enty-immutable/src/__test__/ListSchema-test.js
+++ b/packages/enty-immutable/src/__test__/ListSchema-test.js
@@ -1,5 +1,5 @@
 //@flow
-import EntitySchema from '../EntitySchema';
+import EntitySchema from 'enty';
 import ListSchema from '../ListSchema';
 import MapSchema from '../MapSchema';
 import {fromJS} from 'immutable';

--- a/packages/enty-immutable/src/__test__/MapSchema-test.js
+++ b/packages/enty-immutable/src/__test__/MapSchema-test.js
@@ -1,5 +1,5 @@
 //@flow
-import EntitySchema from 'enty';
+import {EntitySchema} from 'enty';
 import MapSchema from '../MapSchema';
 import {fromJS, Map} from 'immutable';
 

--- a/packages/enty-immutable/src/__test__/MapSchema-test.js
+++ b/packages/enty-immutable/src/__test__/MapSchema-test.js
@@ -1,5 +1,5 @@
 //@flow
-import EntitySchema from '../EntitySchema';
+import EntitySchema from 'enty';
 import MapSchema from '../MapSchema';
 import {fromJS, Map} from 'immutable';
 

--- a/packages/enty-immutable/src/__test__/index-test.js
+++ b/packages/enty-immutable/src/__test__/index-test.js
@@ -1,0 +1,14 @@
+
+//@flow
+import * as EntyImmutable from '../index';
+
+
+test('that index has a defined set of exports', () => {
+    const exportList = Object.keys(EntyImmutable);
+    expect(exportList).toHaveLength(2);
+
+    expect(Enty.MapSchema).toBeDefined();
+    expect(Enty.ListSchema).toBeDefined();
+});
+
+

--- a/packages/enty-immutable/src/__test__/index-test.js
+++ b/packages/enty-immutable/src/__test__/index-test.js
@@ -4,11 +4,12 @@ import * as EntyImmutable from '../index';
 
 
 test('that index has a defined set of exports', () => {
+    expect.assertions(3); // number of exports + 1 for the exportList
     const exportList = Object.keys(EntyImmutable);
     expect(exportList).toHaveLength(2);
 
-    expect(Enty.MapSchema).toBeDefined();
-    expect(Enty.ListSchema).toBeDefined();
+    expect(EntyImmutable.MapSchema).toBeDefined();
+    expect(EntyImmutable.ListSchema).toBeDefined();
 });
 
 

--- a/packages/enty-immutable/src/index.js
+++ b/packages/enty-immutable/src/index.js
@@ -1,0 +1,7 @@
+// @flow
+
+export {default as MapSchema} from './MapSchema';
+export {default as ListSchema} from './ListSchema';
+
+export type {ListSchema as ListSchemaType} from './ListSchema';
+export type {MapSchema as MapSchemaType} from './MapSchema';

--- a/packages/enty/src/__test__/CompositeEntitySchema-test.js
+++ b/packages/enty/src/__test__/CompositeEntitySchema-test.js
@@ -1,11 +1,11 @@
 //@flow
 import EntitySchema from '../EntitySchema';
 import CompositeEntitySchema from '../CompositeEntitySchema';
-import MapSchema from '../MapSchema';
+import ObjectSchema from '../ObjectSchema';
 
-var course = EntitySchema('course').set(MapSchema());
-var dog = EntitySchema('dog').set(MapSchema());
-var participant = EntitySchema('participant').set(MapSchema());
+var course = EntitySchema('course').set(ObjectSchema());
+var dog = EntitySchema('dog').set(ObjectSchema());
+var participant = EntitySchema('participant').set(ObjectSchema());
 
 var courseParticipant = CompositeEntitySchema('courseParticipant', {
     definition: participant,
@@ -34,18 +34,18 @@ const derek = {
 
 
 test('denormalize is the inverse of normalize', () => {
-    expect(courseParticipant.denormalize(courseParticipant.normalize(derek)).toJS()).toEqual(derek);
+    expect(courseParticipant.denormalize(courseParticipant.normalize(derek))).toEqual(derek);
 });
 
 test('cannot be made up of structural types', () => {
     const badDefinition = CompositeEntitySchema('badDefinition', {
-        definition: MapSchema({course})
+        definition: ObjectSchema({course})
     });
 
     const badKeys = CompositeEntitySchema('badKeys', {
         definition: course,
         compositeKeys: {
-            deep: MapSchema({participant})
+            deep: ObjectSchema({participant})
         }
     });
 
@@ -107,12 +107,12 @@ test('can defer their definition', () => {
 
 test('compositeKeys will override defintion keys ', () => {
     const cat = EntitySchema('cat', {
-        definition: MapSchema({
+        definition: ObjectSchema({
             friend: dog
         })
     });
 
-    const owl = EntitySchema('owl').set(MapSchema());
+    const owl = EntitySchema('owl').set(ObjectSchema());
 
     var catOwl = CompositeEntitySchema('catOwl', {
         definition: cat,

--- a/packages/enty/src/__test__/DynamicSchema-test.js
+++ b/packages/enty/src/__test__/DynamicSchema-test.js
@@ -1,12 +1,12 @@
 //@flow
 import EntitySchema from '../EntitySchema';
-import ListSchema from '../ListSchema';
+import ArraySchema from '../ArraySchema';
 import DynamicSchema from '../DynamicSchema';
-import MapSchema from '../MapSchema';
+import ObjectSchema from '../ObjectSchema';
 
-const foo = EntitySchema('foo').set(MapSchema());
-const bar = EntitySchema('bar').set(MapSchema());
-const baz = EntitySchema('baz').set(MapSchema());
+const foo = EntitySchema('foo').set(ObjectSchema());
+const bar = EntitySchema('bar').set(ObjectSchema());
+const baz = EntitySchema('baz').set(ObjectSchema());
 
 const fooBarBaz = DynamicSchema((data: *): * => {
     switch(data.type || data.get('type')) {
@@ -21,7 +21,7 @@ const fooBarBaz = DynamicSchema((data: *): * => {
 
 
 test('DynamicSchema can choose an appropriate schema to normalize', () => {
-    const unknownArray = ListSchema(fooBarBaz);
+    const unknownArray = ArraySchema(fooBarBaz);
     const data = [
         {type: 'foo', id: '0'},
         {type: 'bar', id: '1'},
@@ -30,35 +30,33 @@ test('DynamicSchema can choose an appropriate schema to normalize', () => {
     const {entities} = unknownArray.normalize(data);
 
 
-    expect(entities.foo['0'].toJS()).toEqual(data[0]);
-    expect(entities.bar['1'].toJS()).toEqual(data[1]);
-    expect(entities.baz['2'].toJS()).toEqual(data[2]);
+    expect(entities.foo['0']).toEqual(data[0]);
+    expect(entities.bar['1']).toEqual(data[1]);
+    expect(entities.baz['2']).toEqual(data[2]);
 });
 
 
 test('DynamicSchema.denormalize is the inverse of DynamicSchema.normalize', () => {
-    const schema = ListSchema(fooBarBaz);
+    const schema = ArraySchema(fooBarBaz);
     const data = [
         {type: 'foo', id: '0'},
         {type: 'bar', id: '1'},
         {type: 'baz', id: '2'}
     ];
     const output = schema.denormalize(schema.normalize(data));
-
-
-    expect(data).toEqual(output.toJS());
+    expect(data).toEqual(output);
 });
 
 test('DynamicSchema.normalize', () => {
     const data = {type: 'foo', id: '0'};
     const output = fooBarBaz.denormalize(fooBarBaz.normalize(data));
-    expect(data).toEqual(output.toJS());
+    expect(data).toEqual(output);
 });
 
 
 
 test('DynamicSchema.normalize on to existing data', () => {
-    const schema = ListSchema(fooBarBaz);
+    const schema = ArraySchema(fooBarBaz);
 
     const first = [
         {type: 'foo', id: '0'}
@@ -72,9 +70,9 @@ test('DynamicSchema.normalize on to existing data', () => {
     const {entities} = schema.normalize(first);
     const output = schema.normalize(second, entities);
 
-    expect(output.entities.foo['0'].toJS()).toEqual(first[0]);
-    expect(output.entities.bar['1'].toJS()).toEqual(second[0]);
-    expect(output.entities.baz['2'].toJS()).toEqual(second[1]);
+    expect(output.entities.foo['0']).toEqual(first[0]);
+    expect(output.entities.bar['1']).toEqual(second[0]);
+    expect(output.entities.baz['2']).toEqual(second[1]);
 });
 
 

--- a/packages/enty/src/__test__/EntitySchema-test.js
+++ b/packages/enty/src/__test__/EntitySchema-test.js
@@ -1,21 +1,20 @@
 //@flow
 import EntitySchema from '../EntitySchema';
-import MapSchema from '../MapSchema';
+import ObjectSchema from '../ObjectSchema';
 import {DELETED_ENTITY} from '../util/SchemaConstant';
-import {fromJS} from 'immutable';
 import {NoDefinitionError} from '../util/Error';
 
 var foo = EntitySchema('foo');
 var bar = EntitySchema('bar');
 var baz = EntitySchema('baz');
 
-foo.set(MapSchema({}));
-baz.set(MapSchema({bar}));
-bar.set(MapSchema({foo}));
+foo.set(ObjectSchema({}));
+baz.set(ObjectSchema({bar}));
+bar.set(ObjectSchema({foo}));
 
 test('EntitySchema can set definition through the `set` method', () => {
     var schema = EntitySchema('foo');
-    const definition = MapSchema({bar: "1"});
+    const definition = ObjectSchema({bar: "1"});
     schema.set(definition);
     expect(schema.definition).toBe(definition);
 });
@@ -24,32 +23,32 @@ test('EntitySchema can set definition through the `set` method', () => {
 test('EntitySchema can normalize entities', () => {
     const {entities, result} = foo.normalize({id: "1"});
     expect(result).toBe("1");
-    expect(entities.foo["1"].toJS()).toEqual({id: "1"});
+    expect(entities.foo["1"]).toEqual({id: "1"});
 });
 
 test('EntitySchema can denormalize entities', () => {
-    const entities = fromJS({
+    const entities = {
         foo: {
             "1": {id: "1"}
         }
-    });
+    };
 
-    expect(foo.denormalize({result: "1", entities}).toJS()).toEqual({id: "1"});
+    expect(foo.denormalize({result: "1", entities})).toEqual({id: "1"});
 });
 
 test('EntitySchema will not cause an infinite recursion', () => {
     const foo = EntitySchema('foo');
     const bar = EntitySchema('bar');
 
-    foo.set(MapSchema({bar}));
-    bar.set(MapSchema({foo}));
+    foo.set(ObjectSchema({bar}));
+    bar.set(ObjectSchema({foo}));
 
-    const entities = fromJS({
+    const entities = {
         bar: {"1": {id: "1", foo: "1"}},
         foo: {"1": {id: "1", bar: "1"}}
-    });
+    };
 
-    expect(bar.denormalize({result: "1", entities}).toJS()).toEqual({
+    expect(bar.denormalize({result: "1", entities})).toEqual({
         id: "1",
         foo: {
             id: "1",
@@ -62,9 +61,9 @@ test('EntitySchema will not cause an infinite recursion', () => {
 });
 
 test('EntitySchema will not denormalize null entities', () => {
-    const entities = fromJS({
+    const entities = {
         bar: {"1": {id: "1", foo: null}}
-    });
+    };
 
     expect(bar.denormalize({result: "2", entities})).toEqual(undefined);
 });
@@ -85,11 +84,11 @@ test('will not denormalize null definitions', () => {
 
 
 test('EntitySchema will return DELETED_ENTITY placeholder if denormalizeFilter fails', () => {
-    const entities = fromJS({
+    const entities = {
         foo: {
             "1": {id: "1", deleted: true}
         }
-    });
+    };
 
     expect(foo.denormalize({result: "1", entities})).toEqual(DELETED_ENTITY);
 });

--- a/packages/enty/src/__test__/NullSchema-test.js
+++ b/packages/enty/src/__test__/NullSchema-test.js
@@ -1,9 +1,5 @@
 //@flow
 import NullSchema from '../NullSchema';
-import MapSchema from '../MapSchema';
-import {DELETED_ENTITY} from '../util/SchemaConstant';
-import {fromJS} from 'immutable';
-import {NoDefinitionError} from '../util/Error';
 
 var foo = new NullSchema();
 const denormalizeState = {entities: {}, result: {}};

--- a/packages/enty/src/__test__/ValueSchema-test.js
+++ b/packages/enty/src/__test__/ValueSchema-test.js
@@ -1,14 +1,13 @@
 //@flow
-import { Map } from 'immutable';
 import EntitySchema from '../EntitySchema';
-import MapSchema from '../MapSchema';
+import ObjectSchema from '../ObjectSchema';
 import ValueSchema from '../ValueSchema';
 
 const foo = EntitySchema('foo', {
-    definition: MapSchema({})
-});
+    definition: ObjectSchema({})
+})
 
-const fooValues = MapSchema({
+const fooValues = ObjectSchema({
     foo: ValueSchema(foo)
 });
 
@@ -16,31 +15,29 @@ const fooValues = MapSchema({
 
 test('denormalize is almost the inverse of normalize', () => {
     const data = {foo: '1'};
-    expect(data.foo).toEqual(fooValues.denormalize(fooValues.normalize(data)).toJS().foo.id);
+    expect(data.foo).toEqual(fooValues.denormalize(fooValues.normalize(data)).foo.id);
 });
 
 test('normalize', () => {
-    const data = Map({id: '1'});
+    const data = {id: '1'};
     const entities = {
         foo: {
             "1": data
         }
     };
-    expect(data.equals(ValueSchema(foo).normalize('1', entities).entities.foo['1'])).toBe(true);
-    expect(data.equals(ValueSchema(foo).normalize('1', undefined).entities.foo['1'])).toBe(true);
+    expect(data).toEqual(ValueSchema(foo).normalize('1', entities).entities.foo['1']);
+    expect(data).toEqual(ValueSchema(foo).normalize('1', undefined).entities.foo['1']);
 });
 
 test('denormalize', () => {
-    const data = Map({id: '1'});
+    const data = {id: '1'};
     const entities = {
         foo: {
             "1": data
         }
     };
-    expect(data.equals(ValueSchema(foo).denormalize({result: '1', entities}))).toBe(true);
-    expect(
-        data.equals(ValueSchema(foo).denormalize({result: '1', entities}, undefined))
-    ).toBe(true);
+    expect(data).toEqual(ValueSchema(foo).denormalize({result: '1', entities}));
+    expect(data).toEqual(ValueSchema(foo).denormalize({result: '1', entities}, undefined));
 });
 
 

--- a/packages/enty/src/__test__/index-test.js
+++ b/packages/enty/src/__test__/index-test.js
@@ -3,6 +3,7 @@ import * as Enty from '../index';
 
 
 test('that index has a defined set of exports', () => {
+    expect.assertions(8); // number of exports + 1 for the exportList
     const exportList = Object.keys(Enty);
     expect(exportList).toHaveLength(7);
 

--- a/packages/enty/src/__test__/index-test.js
+++ b/packages/enty/src/__test__/index-test.js
@@ -1,0 +1,18 @@
+//@flow
+import * as Enty from '../index';
+
+
+test('that index has a defined set of exports', () => {
+    const exportList = Object.keys(Enty);
+    expect(exportList).toHaveLength(7);
+
+    expect(Enty.EntitySchema).toBeDefined();
+    expect(Enty.ArraySchema).toBeDefined();
+    expect(Enty.ObjectSchema).toBeDefined();
+    expect(Enty.CompositeEntitySchema).toBeDefined();
+    expect(Enty.NullSchema).toBeDefined();
+    expect(Enty.ValueSchema).toBeDefined();
+    expect(Enty.DynamicSchema).toBeDefined();
+});
+
+

--- a/packages/enty/src/abstract/__test__/Child-test.js
+++ b/packages/enty/src/abstract/__test__/Child-test.js
@@ -1,22 +1,22 @@
 //@flow
 import Child from '../Child';
-import MapSchema from '../../MapSchema';
+import ObjectSchema from '../../ObjectSchema';
 
 it('can set a definition through the constructor', () => {
-    const map = MapSchema();
+    const map = ObjectSchema();
     const child = new Child(map);
     expect(child.definition).toBe(map);
 });
 
 it('can access the definition through get', () => {
-    const map = MapSchema();
+    const map = ObjectSchema();
     const child = new Child(map);
     expect(child.get()).toBe(map);
 });
 
 it('can change the definition through set', () => {
-    const mapA = MapSchema();
-    const mapB = MapSchema();
+    const mapA = ObjectSchema();
+    const mapB = ObjectSchema();
     const child = new Child(mapA);
     expect(child.get()).toBe(mapA);
     expect(child.get()).not.toBe(mapB);
@@ -25,8 +25,8 @@ it('can change the definition through set', () => {
 });
 
 it('can update the definition through update', () => {
-    const mapA = MapSchema();
-    const mapB = MapSchema();
+    const mapA = ObjectSchema();
+    const mapB = ObjectSchema();
     const child = new Child(mapA);
 
     child.update(definition => {

--- a/packages/enty/src/abstract/__test__/Keyed-test.js
+++ b/packages/enty/src/abstract/__test__/Keyed-test.js
@@ -1,22 +1,22 @@
 //@flow
 import Keyed from '../Keyed';
-import MapSchema from '../../MapSchema';
+import ObjectSchema from '../../ObjectSchema';
 
 it('can set a definition through the constructor', () => {
-    const foo = MapSchema();
+    const foo = ObjectSchema();
     const keyed = new Keyed({foo});
     expect(keyed.definition.foo).toBe(foo);
 });
 
 it('can access the definition through get', () => {
-    const foo = MapSchema();
+    const foo = ObjectSchema();
     const keyed = new Keyed({foo});
     expect(keyed.get('foo')).toBe(foo);
 });
 
 it('can change the definition through set', () => {
-    const foo = MapSchema();
-    const bar = MapSchema();
+    const foo = ObjectSchema();
+    const bar = ObjectSchema();
     const keyed = new Keyed({foo});
     expect(keyed.get('foo')).toBe(foo);
     keyed.set('foo', bar);
@@ -25,8 +25,8 @@ it('can change the definition through set', () => {
 
 describe('update', () => {
     test('if the first parameter is a function it will give updater the whole definition', () => {
-        const foo = MapSchema();
-        const bar = MapSchema();
+        const foo = ObjectSchema();
+        const bar = ObjectSchema();
         const keyed = new Keyed({foo});
         keyed.update((obj) => {
             expect(obj).toMatchObject({foo});
@@ -36,8 +36,8 @@ describe('update', () => {
         expect(keyed.get('foo')).toBeUndefined();
     });
     test('if the second parameter is a function it will update only the key provided', () => {
-        const foo = MapSchema();
-        const bar = MapSchema();
+        const foo = ObjectSchema();
+        const bar = ObjectSchema();
         const keyed = new Keyed({foo});
         keyed.update('foo', (obj) => {
             expect(obj).toBe(foo);
@@ -46,8 +46,7 @@ describe('update', () => {
         expect(keyed.get('foo')).toBe(bar);
     });
     test('if no functions are provided it will throw', () => {
-        const foo = MapSchema();
-        const bar = MapSchema();
+        const foo = ObjectSchema();
         const keyed = new Keyed({foo});
         // $FlowFixMe - inentional missue of types for testing
         expect(() => keyed.update('foo', 'wrong!')).toThrow(/function/);

--- a/packages/enty/src/index.js
+++ b/packages/enty/src/index.js
@@ -34,4 +34,5 @@ export type {DenormalizeState} from './util/definitions';
 export type {KeyedDefinition} from './util/definitions';
 export type {ChildDefinition} from './util/definitions';
 export type {Structure} from './util/definitions';
+export type {StructureInput} from './util/definitions';
 export type {Entity} from './util/definitions';

--- a/packages/enty/src/index.js
+++ b/packages/enty/src/index.js
@@ -1,0 +1,37 @@
+// @flow
+
+
+//
+// Schemas
+//
+export {default as ArraySchema} from './ArraySchema';
+export type {ArraySchema as ArraySchemaType} from './ArraySchema';
+
+export {default as CompositeEntitySchema} from './CompositeEntitySchema';
+export type {CompositeEntitySchema as CompositeEntitySchemaType} from './CompositeEntitySchema';
+
+export {default as DynamicSchema} from './DynamicSchema';
+export type {DynamicSchema as DynamicSchemaType} from './DynamicSchema';
+
+export {default as EntitySchema} from './EntitySchema';
+export type {EntitySchema as EntitySchemaType} from './EntitySchema';
+
+export {default as NullSchema} from './NullSchema';
+export type {default as NullSchemaType} from './NullSchema';
+
+export {default as ObjectSchema} from './ObjectSchema';
+export type {ObjectSchema as ObjectSchemaType} from './ObjectSchema';
+
+export {default as ValueSchema} from './ValueSchema';
+export type {ValueSchema as ValueSchemaType} from './ValueSchema';
+
+
+//
+// Supporting Types
+//
+export type {NormalizeState} from './util/definitions';
+export type {DenormalizeState} from './util/definitions';
+export type {KeyedDefinition} from './util/definitions';
+export type {ChildDefinition} from './util/definitions';
+export type {Structure} from './util/definitions';
+export type {Entity} from './util/definitions';

--- a/packages/react-enty/package.json
+++ b/packages/react-enty/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "enty": "^0.49.0-0",
     "fronads": "^0.17.0",
-    "immutable": "^3.8.1",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "redux-actions": "^2.0.1",

--- a/packages/react-enty/src/EntityApi.js
+++ b/packages/react-enty/src/EntityApi.js
@@ -10,9 +10,9 @@ import EntityMutationHockFactory from './EntityMutationHockFactory';
 import EntityReducerFactory from './EntityReducerFactory';
 import EntityStoreFactory from './EntityStoreFactory';
 import EntityProviderFactory from './EntityProviderFactory';
-import {fromJS} from 'immutable';
 import {selectEntityByResult} from './EntitySelector';
 import RequestStateSelector from './RequestStateSelector';
+import Hash from './util/Hash';
 
 import reduce from 'unmutable/lib/reduce';
 import set from 'unmutable/lib/set';
@@ -149,7 +149,7 @@ function EntityApi(schema: Schema<*>, actionMap: Object, hockOptions: HockOption
 
             const HockMeta = {
                 // @TODO: internalize the hashing algorithm
-                generateResultKey: (payload) => fromJS({payload, actionName}).hashCode().toString(),
+                generateResultKey: (payload) => Hash({payload, actionName}),
                 requestActionName: actionName,
                 schemaKey: hockOptions.schemaKey, // @TODO remove this when there is only a single schema per api
                 storeKey,

--- a/packages/react-enty/src/EntityMutationHockFactory.js
+++ b/packages/react-enty/src/EntityMutationHockFactory.js
@@ -6,9 +6,9 @@ import RequestStateSelector from './RequestStateSelector';
 import {selectEntityByResult} from './EntitySelector';
 import DistinctMemo from './util/DistinctMemo';
 import Connect from './util/Connect';
-import {fromJS} from 'immutable';
 import React, {type Element} from 'react';
 import Deprecated from './util/Deprecated';
+import Hash from './util/Hash';
 
 /**
  * EntityMutationHockFactory
@@ -108,7 +108,7 @@ export default function EntityMutationHockFactory(actionCreator: Function, hockO
                 updateMutation(props: Object) {
                     this.mutation = (data: Object) => {
                         const payload = payloadCreator(data);
-                        const resultKey = updateResultKey(options.resultKey || fromJS({hash: payload}).hashCode() + options.requestActionName, props);
+                        const resultKey = updateResultKey(options.resultKey || Hash({hash: payload}) + options.requestActionName, props);
                         this.setState({resultKey});
                         props.dispatch(actionCreator(payload, {...options, resultKey}));
                     };

--- a/packages/react-enty/src/EntityQueryHockFactory.js
+++ b/packages/react-enty/src/EntityQueryHockFactory.js
@@ -6,12 +6,12 @@ import type {HockOptions} from './util/definitions';
 import type {Hock} from './util/definitions';
 
 import PropChangeHock from 'stampy/lib/hock/PropChangeHock';
-import {fromJS} from 'immutable';
 import RequestStateSelector from './RequestStateSelector';
 import {selectEntityByResult} from './EntitySelector';
 import DistinctMemo from './util/DistinctMemo';
 import Connect from './util/Connect';
 import Deprecated from './util/Deprecated';
+import Hash from './util/Hash';
 
 
 /**
@@ -67,7 +67,7 @@ function EntityQueryHockFactory(actionCreator: Function, hockOptions?: HockOptio
 
 
             function getHash(props: Object, options: HockOptions): string {
-                return (options.resultKey || fromJS({hash: queryCreator(props), requestActionName: options.requestActionName}).hashCode()) + '';
+                return options.resultKey || Hash({hash: queryCreator(props), requestActionName: options.requestActionName});
             }
 
             const withState = Connect((state: Object, props: Object): Object => {

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -38,9 +38,9 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
             _error: {},
             _requestState: {},
             _entities: {},
-            _stats: Map({
+            _stats: {
                 normalizeCount: 0
-            })
+            }
         });
 
 

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -5,6 +5,7 @@ import type {Structure} from 'enty/lib/util/definitions';
 import {Map} from 'immutable';
 import updateIn from 'unmutable/lib/updateIn';
 import setIn from 'unmutable/lib/setIn';
+import getIn from 'unmutable/lib/getIn';
 import deleteIn from 'unmutable/lib/deleteIn';
 import set from 'unmutable/lib/set';
 import clone from 'unmutable/lib/clone';
@@ -35,7 +36,7 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
             _schemas: {},
             _result: {},
             _error: {},
-            _requestState: Map(),
+            _requestState: {},
             _entities: {},
             _stats: Map({
                 normalizeCount: 0
@@ -62,11 +63,11 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
         //
         // Set Request States for BLANK/FETCH/ERROR
         if(/_FETCH$/g.test(type)) {
-            if(state.getIn(requestStatePath)) {
+            if(getIn(requestStatePath)(state)) {
                 Logger.info(`Setting RefetchingState for "${requestStatePath.join('.')}"`);
-                state = state.setIn(requestStatePath, RefetchingState());
+                state = setIn(requestStatePath, RefetchingState())(state);
             } else {
-                state = state.setIn(requestStatePath, FetchingState());
+                state = setIn(requestStatePath, FetchingState())(state);
                 Logger.info(`Setting FetchingState for "${requestStatePath.join('.')}"`, state);
             }
         } else if(/_ERROR$/g.test(type)) {
@@ -92,7 +93,7 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
 
             // set success action before payload tests
             // to make sure the request state is still updated even if there is no payload
-            state = state.setIn(requestStatePath, SuccessState());
+            state = setIn(requestStatePath, SuccessState())(state);
 
             if(schema && payload) {
                 const {result, entities, schemas} = schema.normalize(

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -48,13 +48,8 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
             }
         };
 
-        const {resultKey = type} = meta;
-
-
-        // @FIXME: resultKey should be defined before the reducer.
-        // The reducer should not have to infer any data.
-        var [, actionTypePrefix] = resultKey.toString().match(/(.*)_(FETCH|ERROR|RECEIVE)$/) || [];
-        const requestStatePath = ['_requestState', actionTypePrefix || resultKey];
+        const {resultKey} = meta;
+        const requestStatePath = ['_requestState', resultKey];
         const errorPath = ['_error', resultKey];
 
 

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -2,16 +2,15 @@
 import type {Schema} from 'enty/lib/util/definitions';
 import type {Structure} from 'enty/lib/util/definitions';
 
-import {Map} from 'immutable';
-import updateIn from 'unmutable/lib/updateIn';
-import setIn from 'unmutable/lib/setIn';
-import getIn from 'unmutable/lib/getIn';
-import deleteIn from 'unmutable/lib/deleteIn';
-import set from 'unmutable/lib/set';
 import clone from 'unmutable/lib/clone';
+import deleteIn from 'unmutable/lib/deleteIn';
 import get from 'unmutable/lib/get';
+import getIn from 'unmutable/lib/getIn';
 import merge from 'unmutable/lib/merge';
 import pipeWith from 'unmutable/lib/util/pipeWith';
+import set from 'unmutable/lib/set';
+import setIn from 'unmutable/lib/setIn';
+import updateIn from 'unmutable/lib/updateIn';
 
 import {FetchingState} from './RequestState';
 import {RefetchingState} from './RequestState';
@@ -31,7 +30,7 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
 
         Logger.info(`\n\nEntity reducer:`);
 
-        let state = previousState || Map({
+        let state = previousState || {
             _baseSchema: schema,
             _schemas: {},
             _result: {},
@@ -41,7 +40,7 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
             _stats: {
                 normalizeCount: 0
             }
-        });
+        };
 
 
         const {

--- a/packages/react-enty/src/EntityReducerFactory.js
+++ b/packages/react-enty/src/EntityReducerFactory.js
@@ -19,32 +19,13 @@ import {SuccessState} from './RequestState';
 import Logger from './Logger';
 
 
-
-
-/**
- *
- * @example
- * import {createEntityReducer} from 'enty';
- * import EntitySchema from 'myapp/EntitySchema';
- *
- * export default combineReducers({
- *     entity: EntityReducerFactory({
- *          schemaMap: {
- *              GRAPHQL_RECEIVE: EntitySchema,
- *              MY_CUSTOM_ACTION_RECEIVE: EntitySchema.myCustomActionSchema
- *          }
- *     })
- * });
- */
 export default function EntityReducerFactory(config: {schema: Schema<Structure>}): Function {
     const {schema} = config;
-
 
     const defaultMeta = {
         resultResetOnFetch: false
     };
 
-    // Return our constructed reducer
     return function EntityReducer(previousState: *, {type, payload, meta}: Object): Map<any, any> {
 
         Logger.info(`\n\nEntity reducer:`);
@@ -53,7 +34,7 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
             _baseSchema: schema,
             _schemas: {},
             _result: {},
-            _error: Map(),
+            _error: {},
             _requestState: Map(),
             _entities: {},
             _stats: Map({
@@ -72,7 +53,6 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
         // The reducer should not have to infer any data.
         var [, actionTypePrefix] = resultKey.toString().match(/(.*)_(FETCH|ERROR|RECEIVE)$/) || [];
         const requestStatePath = ['_requestState', actionTypePrefix || resultKey];
-
         const errorPath = ['_error', resultKey];
 
 
@@ -91,10 +71,11 @@ export default function EntityReducerFactory(config: {schema: Schema<Structure>}
             }
         } else if(/_ERROR$/g.test(type)) {
             Logger.info(`Setting ErrorState for "${requestStatePath.join('.')}"`);
-            state = state
-                .setIn(requestStatePath, ErrorState(payload))
-                .setIn(errorPath, payload)
-            ;
+            state = pipeWith(
+                state,
+                setIn(requestStatePath, ErrorState(payload)),
+                setIn(errorPath, payload)
+            );
         }
 
 

--- a/packages/react-enty/src/EntitySelector.js
+++ b/packages/react-enty/src/EntitySelector.js
@@ -1,10 +1,13 @@
 //@flow
-import {Iterable} from 'immutable';
 import ArraySchema from 'enty/lib/ArraySchema';
 import getIn from 'unmutable/lib/getIn';
 import get from 'unmutable/lib/get';
 import keyArray from 'unmutable/lib/keyArray';
+import toArray from 'unmutable/lib/toArray';
+import toObject from 'unmutable/lib/toObject';
 import pipeWith from 'unmutable/lib/util/pipeWith';
+import isIndexed from 'unmutable/lib/util/isIndexed';
+import doIf from 'unmutable/lib/doIf';
 import KeyedMemo from './util/KeyedMemo';
 
 /**
@@ -39,10 +42,10 @@ export function selectEntityByResult(state: Object, resultKey: string, options: 
         () => schema.denormalize({result, entities})
     );
 
-    if(Iterable.isIndexed(data)) {
-        return data.toArray ? data.toArray() : data;
-    }
-    return data.toObject ? data.toObject() : data;
+    return pipeWith(
+        data,
+        doIf(isIndexed, toArray(), toObject())
+    );
 }
 
 /**

--- a/packages/react-enty/src/ErrorSelector.js
+++ b/packages/react-enty/src/ErrorSelector.js
@@ -1,6 +1,7 @@
 // @flow
+import getIn from 'unmutable/lib/getIn';
+import pipeWith from 'unmutable/lib/util/pipeWith';
 import Logger from './Logger';
-
 
 /**
  * @module Selectors
@@ -16,6 +17,8 @@ export default function ErrorSelector(state: Object, resultKey: string, options?
     const {stateKey = 'entity'} = options;
 
     Logger.silly('Selecting Error:', `${stateKey}._error.${resultKey}`, state);
-    return state[stateKey]
-        .getIn(['_error', resultKey]);
+    return pipeWith(
+        state,
+        getIn([stateKey, '_error', resultKey])
+    );
 }

--- a/packages/react-enty/src/Logger.js
+++ b/packages/react-enty/src/Logger.js
@@ -1,5 +1,5 @@
 // @flow
-import {List} from 'immutable';
+import findIndex from 'unmutable/lib/findIndex';
 
 type Logger = {
     logLevel: number,
@@ -7,7 +7,7 @@ type Logger = {
     [key: string]: Function
 };
 
-const logLevels = List([
+const logLevels = [
     {
         name: 'error',
         consoleMethod: 'error'
@@ -28,7 +28,7 @@ const logLevels = List([
         name: 'silly',
         consoleMethod: 'log'
     }
-]);
+];
 
 var logger: Logger = {
 
@@ -70,7 +70,7 @@ var logger: Logger = {
     getLevelIndex: function(level: number|string): number {
         // level can be a log level string like "error" or "silly", or a number corresponding to a log level
         return typeof level == "string"
-            ? logLevels.findIndex(ii => ii.name == level.toString())
+            ? findIndex(ii => ii.name == level.toString())(logLevels)
             : level;
     }
 };

--- a/packages/react-enty/src/RequestState.js
+++ b/packages/react-enty/src/RequestState.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {StateFunctorFactory} from 'fronads';
+import {StateFunctorFactoryFactory as StateFunctorFactory} from 'fronads/lib/StateFunctor';
 
 /**
  * Mapper description

--- a/packages/react-enty/src/RequestStateSelector.js
+++ b/packages/react-enty/src/RequestStateSelector.js
@@ -1,4 +1,6 @@
 // @flow
+import getIn from 'unmutable/lib/getIn';
+import pipeWith from 'unmutable/lib/util/pipeWith';
 import {EmptyState} from './RequestState';
 import Logger from './Logger';
 
@@ -17,6 +19,8 @@ export default function selectRequestState(state: Object, requestStateKey: strin
     const {stateKey = 'entity'} = options;
 
     Logger.silly('Selecting RequestState:', `${stateKey}._requestState.${requestStateKey}`, state);
-    return state[stateKey]
-        .getIn(['_requestState', requestStateKey], EmptyState());
+    return pipeWith(
+        state,
+        getIn([stateKey, '_requestState', requestStateKey], EmptyState())
+    );
 }

--- a/packages/react-enty/src/__test__/EntityQueryHockFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityQueryHockFactory-test.js
@@ -48,7 +48,7 @@ test('resultKey is derived either from the metaOverride or a hash of the queryCr
     };
 
     const sideEffectB = (aa: any, bb: any) => {
-        expect(bb.resultKey).toBe('431296113');
+        expect(bb.resultKey).toBe('3938');
     };
 
 

--- a/packages/react-enty/src/__test__/EntityReducerFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityReducerFactory-test.js
@@ -121,40 +121,6 @@ describe('EntityReducer Config', () => {
 
 });
 
-describe('EntityReducer resultResetOnFetch', () => {
-    test('if true it will delete resultKey on FETCH action', () => {
-        const initialState = Map({
-            _result: Map({
-                FOO: 'FOO',
-                BAR: 'BAR'
-            })
-        });
-        const state = EntityReducer(initialState, {
-            type: 'FOO_FETCH',
-            meta: {resultKey: 'FOO', resultResetOnFetch: true}
-        });
-
-        expect(getIn(['_result', 'FOO'])(state)).toBe(undefined);
-        expect(getIn(['_result', 'BAR'])(state)).toBe('BAR');
-    });
-
-    test('if false it will not delete resultKey on FETCH action', () => {
-        const initialState = Map({
-            _result: Map({
-                FOO: 'FOO',
-                BAR: 'BAR'
-            })
-        });
-        const state = EntityReducer(initialState, {
-            type: 'FOO_FETCH',
-            meta: {resultKey: 'FOO', resultResetOnFetch: false}
-        });
-
-        expect(getIn(['_result', 'FOO'])(state)).toBe('FOO');
-        expect(getIn(['_result', 'BAR'])(state)).toBe('BAR');
-    });
-});
-
 describe('EntityReducer Normalizing', () => {
     test('it will store normalized results on _result.resultKey', () => {
         const action = {

--- a/packages/react-enty/src/__test__/EntityReducerFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityReducerFactory-test.js
@@ -98,12 +98,11 @@ describe('EntityReducer requestState', () => {
 
 describe('EntityReducer Config', () => {
     test('the supplied schema is not mutated when reducing', () => {
-        expect(EntityReducer(undefined, {type: 'nothing'}).get('_baseSchema'))
-            .toBe(schema);
+        expect(EntityReducer(undefined, {type: 'nothing'})._baseSchema).toBe(schema);
     });
 
     test('result starts with an empty object', () => {
-        expect(EntityReducer(undefined, {type: 'nothing'}).get('_result')).toEqual({});
+        expect(EntityReducer(undefined, {type: 'nothing'})._result).toEqual({});
     });
 
     test('will not change state if actions do not match _(FETCH|RECIEVE|ERROR)', () => {

--- a/packages/react-enty/src/__test__/EntityReducerFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityReducerFactory-test.js
@@ -1,31 +1,30 @@
 //@flow
 import EntityReducerFactory from '../EntityReducerFactory';
 import EntitySchema from 'enty/lib/EntitySchema';
-import ListSchema from 'enty/lib/ListSchema';
-import MapSchema from 'enty/lib/MapSchema';
+import ArraySchema from 'enty/lib/ArraySchema';
+import ObjectSchema from 'enty/lib/ObjectSchema';
 import get from 'unmutable/lib/get';
 import getIn from 'unmutable/lib/getIn';
 import pipeWith from 'unmutable/lib/util/pipeWith';
-import {is, fromJS, Map} from 'immutable';
 
 //
 // Schemas
 //
 
 var author = EntitySchema('author', {idAtribute: get('fullnameId')})
-    .set(MapSchema({}))
+    .set(ObjectSchema({}));
 
 var topListings = EntitySchema('topListings', {
     idAttribute: get('fullnameId'),
-    definition: MapSchema({author})
+    definition: ObjectSchema({author})
 });
 
 var subreddit = EntitySchema('subreddit', {
     idAttribute: get('fullnameId'),
-    definition: MapSchema({topListings: ListSchema(topListings)})
+    definition: ObjectSchema({topListings: ArraySchema(topListings)})
 });
 
-const schema = MapSchema({
+const schema = ObjectSchema({
     subreddit
 });
 
@@ -34,11 +33,11 @@ const EntityReducer = EntityReducerFactory({schema});
 
 // Mock data
 
-const INITIAL_STATE = fromJS({
+const INITIAL_STATE = {
     thing: {
         abc: '123'
     }
-});
+};
 
 test('EntityReducerFactory normalizes a reuslt', () => {
     const examplePayload = {
@@ -162,7 +161,7 @@ describe('EntityReducer Normalizing', () => {
         return pipeWith(
             EntityReducer(undefined, action),
             getIn(['_entities', 'subreddit', 'MK']),
-            data => expect(data.toJS()).toEqual(action.payload.subreddit)
+            data => expect(data).toEqual(action.payload.subreddit)
         );
     });
 
@@ -184,7 +183,7 @@ describe('EntityReducer Normalizing', () => {
         return pipeWith(
             EntityReducer(undefined, action),
             getIn(['_entities', 'topListings', 'FOO']),
-            data => expect(data.toJS()).toEqual({fullnameId: 'FOO'})
+            data => expect(data).toEqual({fullnameId: 'FOO'})
         );
     });
 
@@ -247,9 +246,9 @@ describe('EntityReducer Normalizing', () => {
         expect(getIn(['_entities', 'subreddit', 'MK', 'name'])(mergeStateTwo)).toBe(payloadB.subreddit.name);
         expect(getIn(['_entities', 'subreddit', 'MK', 'tags'])(mergeStateTwo)).toEqual(payloadB.subreddit.tags);
         expect(getIn(['_entities', 'subreddit', 'MK', 'code'])(mergeStateTwo)).toBe(payloadA.subreddit.code);
-        expect(getIn(['_entities', 'topListings', 'NT'])(mergeStateTwo).toJS()).toEqual(payloadB.subreddit.topListings[0]);
-        expect(getIn(['_entities', 'topListings', 'CT'])(mergeStateTwo).toJS()).toEqual(payloadA.subreddit.topListings[0]);
-        expect(getIn(['_entities', 'topListings', 'GL'])(mergeStateTwo).toJS()).toEqual(payloadB.subreddit.topListings[1]);
+        expect(getIn(['_entities', 'topListings', 'NT'])(mergeStateTwo)).toEqual(payloadB.subreddit.topListings[0]);
+        expect(getIn(['_entities', 'topListings', 'CT'])(mergeStateTwo)).toEqual(payloadA.subreddit.topListings[0]);
+        expect(getIn(['_entities', 'topListings', 'GL'])(mergeStateTwo)).toEqual(payloadB.subreddit.topListings[1]);
 
     });
 });

--- a/packages/react-enty/src/__test__/EntityReducerFactory-test.js
+++ b/packages/react-enty/src/__test__/EntityReducerFactory-test.js
@@ -66,9 +66,11 @@ test('EntityReducerFactory normalizes a reuslt', () => {
 
 describe('EntityReducer requestState', () => {
     test('_requestState.isFetching is true when action type ends with _FETCH', () => {
-        expect(
-            EntityReducer(undefined, {type: 'TEST_FETCH'}).getIn(['_requestState', 'TEST']).isFetching
-        ).toBe(true);
+        const data = pipeWith(
+            EntityReducer(undefined, {type: 'TEST_FETCH'}),
+            getIn(['_requestState', 'TEST'])
+        );
+        expect(data.isFetching).toBe(true);
     });
 
     test('will not be set if action type does not match _(FETCH|ERROR|RECIEVE)', () => {

--- a/packages/react-enty/src/__test__/EntitySelector-test.js
+++ b/packages/react-enty/src/__test__/EntitySelector-test.js
@@ -27,6 +27,7 @@ function constructState(): * {
             undefined,
             {
                 type: 'FOO_RECEIVE',
+                meta: {resultKey: 'FOO'},
                 payload: {
                     foo: {id: 'qux'},
                     fooList: [{id: 'bar'}, {id: 'baz'}, {id: 'qux'}]
@@ -42,7 +43,7 @@ function constructState(): * {
 // selectEntityByResult()
 
 test('selectEntityByResult() should return a map for single items', () => {
-    const data = selectEntityByResult(constructState(), 'FOO_RECEIVE');
+    const data = selectEntityByResult(constructState(), 'FOO');
     expect(data && data.foo).toBeTruthy();
 });
 
@@ -52,6 +53,7 @@ test('selectEntityByResult() should return an array for indexed items', () => {
         undefined,
         {
             type: 'FOOLIST_RECEIVE',
+            meta: {resultKey: 'FOOLIST_RECEIVE'},
             payload: [{id: 'bar'}, {id: 'baz'}]
         }
     )};

--- a/packages/react-enty/src/__test__/RequestHockFactory-test.js
+++ b/packages/react-enty/src/__test__/RequestHockFactory-test.js
@@ -2,8 +2,6 @@
 import type {HockMeta} from '../util/definitions';
 
 import React from 'react';
-import {fromJS} from 'immutable';
-import {Map} from 'immutable';
 import RequestHockFactory from '../RequestHockFactory';
 import RequestStateSelector from '../RequestStateSelector';
 import {FetchingState} from '../RequestState';
@@ -13,7 +11,6 @@ import {ErrorState} from '../RequestState';
 import {SuccessState} from '../RequestState';
 import Message from '../data/Message';
 import {RequestHockNoNameError} from '../util/Error';
-import MapSchema from 'enty/lib/MapSchema';
 import ObjectSchema from 'enty/lib/ObjectSchema';
 import identity from 'unmutable/lib/identity';
 
@@ -25,7 +22,7 @@ const STORE = {
     subscribe: () => {},
     dispatch: (aa) => aa,
     getState: () => ({
-        entity: fromJS({
+        entity: {
             _baseSchema: ObjectSchema({
                 entity: ObjectSchema({})
             }),
@@ -37,7 +34,7 @@ const STORE = {
             _requestState: {
                 foo: FetchingState()
             }
-        })
+        }
     })
 };
 

--- a/packages/react-enty/src/__test__/index-test.js
+++ b/packages/react-enty/src/__test__/index-test.js
@@ -4,7 +4,9 @@ import * as ReactEnty from '../index';
 
 test('that index has a defined set of exports', () => {
     const exportList = Object.keys(ReactEnty);
-    expect(exportList).toHaveLength(18);
+
+    expect.assertions(18); // number of exports + 1 for the exportList
+    expect(exportList).toHaveLength(17);
 
     expect(ReactEnty.EntitySchema).toBeDefined();
     expect(ReactEnty.ArraySchema).toBeDefined();
@@ -15,7 +17,17 @@ test('that index has a defined set of exports', () => {
     expect(ReactEnty.DynamicSchema).toBeDefined();
 
 
-    expect(ReactEnty.DynamicSchema).toBeDefined();
+    expect(ReactEnty.EntityApi).toBeDefined();
+    expect(ReactEnty.selectEntityByResult).toBeDefined();
+    expect(ReactEnty.selectEntityById).toBeDefined();
+    expect(ReactEnty.selectEntityByType).toBeDefined();
+    expect(ReactEnty.selectRequestState).toBeDefined();
+
+    expect(ReactEnty.EmptyState).toBeDefined();
+    expect(ReactEnty.FetchingState).toBeDefined();
+    expect(ReactEnty.RefetchingState).toBeDefined();
+    expect(ReactEnty.ErrorState).toBeDefined();
+    expect(ReactEnty.SuccessState).toBeDefined();
 });
 
 

--- a/packages/react-enty/src/__test__/index-test.js
+++ b/packages/react-enty/src/__test__/index-test.js
@@ -1,0 +1,47 @@
+//@flow
+import * as ReactEnty from '../index';
+
+
+test('that index has a defined set of exports', () => {
+    const exportList = Object.keys(ReactEnty);
+    expect(exportList).toHaveLength(18);
+
+    expect(ReactEnty.EntitySchema).toBeDefined();
+    expect(ReactEnty.ArraySchema).toBeDefined();
+    expect(ReactEnty.ObjectSchema).toBeDefined();
+    expect(ReactEnty.CompositeEntitySchema).toBeDefined();
+    expect(ReactEnty.NullSchema).toBeDefined();
+    expect(ReactEnty.ValueSchema).toBeDefined();
+    expect(ReactEnty.DynamicSchema).toBeDefined();
+
+
+    expect(ReactEnty.DynamicSchema).toBeDefined();
+});
+
+
+//export {default as ArraySchema} from 'enty/lib/ArraySchema';
+//export {default as CompositeEntitySchema} from 'enty/lib/CompositeEntitySchema';
+//export {default as DynamicSchema} from 'enty/lib/DynamicSchema';
+//export {default as EntitySchema} from 'enty/lib/EntitySchema';
+//export {default as ListSchema} from 'enty/lib/ListSchema';
+//export {default as MapSchema} from 'enty/lib/MapSchema';
+//export {default as ObjectSchema} from 'enty/lib/ObjectSchema';
+//export {default as ValueSchema} from 'enty/lib/ValueSchema';
+
+//// Api
+//export {default as EntityApi} from './EntityApi';
+
+
+//// Selectors
+//export {selectEntityByResult} from './EntitySelector';
+//export {selectEntityById} from './EntitySelector';
+//export {selectEntityByType} from './EntitySelector';
+//export {default as selectRequestState} from './RequestStateSelector';
+
+
+//// Misc
+//export {EmptyState} from './RequestState';
+//export {FetchingState} from './RequestState';
+//export {RefetchingState} from './RequestState';
+//export {ErrorState} from './RequestState';
+//export {SuccessState} from './RequestState';

--- a/packages/react-enty/src/index.js
+++ b/packages/react-enty/src/index.js
@@ -6,10 +6,9 @@ export {default as ArraySchema} from 'enty/lib/ArraySchema';
 export {default as CompositeEntitySchema} from 'enty/lib/CompositeEntitySchema';
 export {default as DynamicSchema} from 'enty/lib/DynamicSchema';
 export {default as EntitySchema} from 'enty/lib/EntitySchema';
-export {default as ListSchema} from 'enty/lib/ListSchema';
-export {default as MapSchema} from 'enty/lib/MapSchema';
 export {default as ObjectSchema} from 'enty/lib/ObjectSchema';
 export {default as ValueSchema} from 'enty/lib/ValueSchema';
+export {default as NullSchema} from 'enty/lib/NullSchema';
 
 // Api
 export {default as EntityApi} from './EntityApi';
@@ -23,12 +22,6 @@ export {default as selectRequestState} from './RequestStateSelector';
 
 
 // Misc
-export {default as EntityMutationHockFactory} from './EntityMutationHockFactory';
-export {default as EntityQueryHockFactory} from './EntityQueryHockFactory';
-export {default as EntityReducerFactory} from './EntityReducerFactory';
-export {default as MultiMutationHockFactory} from './MultiMutationHockFactory';
-export {default as MultiQueryHockFactory} from './MultiQueryHockFactory';
-
 export {EmptyState} from './RequestState';
 export {FetchingState} from './RequestState';
 export {RefetchingState} from './RequestState';

--- a/packages/react-enty/src/util/Hash.js
+++ b/packages/react-enty/src/util/Hash.js
@@ -12,8 +12,7 @@ function hashCode(str: string, max?: number): number {
     return Math.abs(max ? hash % max : hash);
 }
 
-export default function Hash(data: *) {
+export default function Hash(data: *): string {
     return hashCode(JSON.stringify(data)) + '';
     //return fromJS(data).hashCode().toString();
 }
-

--- a/packages/react-enty/src/util/Hash.js
+++ b/packages/react-enty/src/util/Hash.js
@@ -1,7 +1,19 @@
 // @flow
-import {fromJS} from 'immutable';
+//import {fromJS} from 'immutable';
+
+function hashCode(str: string, max?: number): number {
+    var hash = 0;
+    if (!str.length) return hash;
+    for (var i = 0; i < str.length; i++) {
+        let char = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash; // Convert to 32bit integer
+    }
+    return Math.abs(max ? hash % max : hash);
+}
 
 export default function Hash(data: *) {
-    return fromJS(data).hashCode().toString();
+    return hashCode(JSON.stringify(data)) + '';
+    //return fromJS(data).hashCode().toString();
 }
 

--- a/packages/react-enty/src/util/Hash.js
+++ b/packages/react-enty/src/util/Hash.js
@@ -1,0 +1,7 @@
+// @flow
+import {fromJS} from 'immutable';
+
+export default function Hash(data: *) {
+    return fromJS(data).hashCode().toString();
+}
+

--- a/packages/react-enty/src/util/definitions.js
+++ b/packages/react-enty/src/util/definitions.js
@@ -10,7 +10,7 @@ export type HockOptions = {
     onMutateProp?: string,
     propChangeKeys: Array<string>,
     propUpdate: (Object) => Object,
-    requestActionName?: string,
+    requestActionName: string,
     updateResultKey: (string, Object) => string,
     resultKey?: string,
     schemaKey?: string,

--- a/taskell.md
+++ b/taskell.md
@@ -6,7 +6,6 @@
 
 ## Current Release
 
-- Remove immutable from reducer
 - Check and remove result reset on fetch
 
 ## In Progress
@@ -17,3 +16,4 @@
 - Stop Flattening the api
 - Create an entity provider
 - Move Entities to sub key
+- Remove immutable from reducer

--- a/taskell.md
+++ b/taskell.md
@@ -1,12 +1,11 @@
 ## Backlog
 
-- Add request hock caching
+- Add api level caching
 - Deprecate select by type and id
 - Remove Stampy Dependency
 
 ## Current Release
 
-- Check and remove result reset on fetch
 
 ## In Progress
 
@@ -17,3 +16,4 @@
 - Create an entity provider
 - Move Entities to sub key
 - Remove immutable from reducer
+- Check and remove result reset on fetch

--- a/taskell.md
+++ b/taskell.md
@@ -1,11 +1,11 @@
 ## Backlog
 
 - Add api level caching
-- Deprecate select by type and id
-- Remove Stampy Dependency
-- internalize hash function
 
 ## Current Release
+
+- Remove Stampy Dependency
+- Deprecate select by type and id
 
 ## In Progress
 
@@ -17,3 +17,4 @@
 - Move Entities to sub key
 - Remove immutable from reducer
 - Check and remove result reset on fetch
+- internalize hash function

--- a/taskell.md
+++ b/taskell.md
@@ -3,9 +3,9 @@
 - Add api level caching
 - Deprecate select by type and id
 - Remove Stampy Dependency
+- internalize hash function
 
 ## Current Release
-
 
 ## In Progress
 

--- a/taskell.md
+++ b/taskell.md
@@ -6,6 +6,7 @@
 
 - Remove Stampy Dependency
 - Deprecate select by type and id
+- Upgrade StateFunctor to Variant
 
 ## In Progress
 


### PR DESCRIPTION
## Core Changes
* Replace immutable in Reducer with plain JS and unmutable.
* BREAK: Move MapSchema and ListSchema out to their own package `enty-immutable`
* BREAK: use internal hashing function. (JSON stringify + Java string.hashcode())

## Minor Changes along for the ride.
* Remove immutable from core enty tests
* BREAK: Stop auto generating a result key
* BREAK: Remove resultResetOnFetch (deprecated by the refetching variant)
* Use full path to StateFunctor so as no to pull in all of fronads