### PR TITLE
break: add an optimism to RequestHock

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,3 +17,6 @@ node_modules/blueflag-test/flow-typed-shims/jest-enzyme-6.0.x/
 <PROJECT_ROOT>/.*/gatsby-node.js
 <PROJECT_ROOT>/packages/enty-docs/.*
 <PROJECT_ROOT>/node_modules/immutable
+
+[untyped]
+.*/lru-memoize/.*

--- a/packages/enty-state/src/EntityApiFactory.js
+++ b/packages/enty-state/src/EntityApiFactory.js
@@ -1,12 +1,9 @@
 //@flow
-import type {Schema} from 'enty/lib/util/definitions';
 
 import Hash from './util/Hash';
 import visitActionMap from './api/visitActionMap';
 import createRequestAction from './api/createRequestAction';
 
-import set from 'unmutable/lib/set';
-import pipeWith from 'unmutable/lib/util/pipeWith';
 
 type ActionMap = {
     [key: string]: *

--- a/packages/react-enty/package.json
+++ b/packages/react-enty/package.json
@@ -23,12 +23,14 @@
   },
   "dependencies": {
     "enty": "^0.50.0-alpha.0",
-    "enty-state": "^0.0.0",
+    "enty-state": "0.0.0",
     "fronads": "^0.18.0",
+    "lru-memoize": "^1.1.0",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "redux-actions": "^2.0.1",
     "redux-thunk": "^2.1.0",
     "unmutable": "^0.39.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/react-enty/src/RequestHockFactory.js
+++ b/packages/react-enty/src/RequestHockFactory.js
@@ -28,6 +28,8 @@ import equals from 'unmutable/lib/equals';
 // filter out redux props.
 // eslint-disable-next-line no-unused-vars
 const filterReduxProps = ({store, dispatch, storeSubscription, ...props}) => props;
+const returnObject: (payload?: mixed) => Object = () => ({});
+const returnTrue: (payload?: mixed) => boolean = () => true;
 
 /**
  * RequestHockFactory
@@ -52,14 +54,14 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
              */
             function RequestHockApplier(Component: ComponentType<*>): ComponentType<*> {
 
-                const {payloadCreator = () => ({})} = config;
+                const {payloadCreator = returnObject} = config;
                 const {updateResultKey = identity()} = config;
                 const {name} = config;
                 const {optimistic = true} = config;
                 const {mapResponseToProps} = config;
 
                 // Auto Props
-                const {shouldComponentAutoRequest = () => true} = config;
+                const {shouldComponentAutoRequest = returnTrue} = config;
                 const {auto = false} = config;
                 const paths = typeof auto === 'boolean' ? [] : auto;
 
@@ -88,7 +90,6 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
                         }
 
                         static getDerivedStateFromProps(pollutedProps, state) {
-                            //if(config.log) console.log('getDerivedStateFromProps', state);
                             let resultKeys;
                             const props = filterReduxProps(pollutedProps);
                             const getPath = (path) => getIn(path.split('.'));
@@ -101,10 +102,8 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
                                     return !equals(previous)(next);
                                 });
 
-                            //!
                             if(auto) {
                                 if(propsHaveChanged && shouldComponentAutoRequest(props) || !state.previousProps) {
-                                    //if(config.log) console.log('propChange', paths);
                                     resultKeys = RequestHock.request(pollutedProps.dispatch, props, payloadCreator(props), state.nextResultKey);
                                 }
                             }
@@ -114,7 +113,7 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
                                     return setPath(path, getPath(path)(props))(rr);
                                 }, {}),
                                 ...resultKeys
-                            }
+                            };
 
                         }
 
@@ -125,14 +124,13 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
                                     props
                                 ),
                                 resultKey: existingResultKey
-                            }
+                            };
                         }
 
                         static request(dispatch: Function, props, payload, existingResultKey?: any) {
                             return pipeWith(
                                 RequestHock.deriveResponseKey(props, payload, existingResultKey),
                                 nextState => {
-                                    //if(config.log) console.log('request', nextState);
                                     dispatch(actionCreator(payload, {
                                         resultKey: nextState.nextResultKey
                                     }));
@@ -219,7 +217,6 @@ function mapResponseToProps({name, ...config}: RequestHockConfigInput): (Object 
         );
     }
 
-    // eslint-disable-next-line no-unused-vars
-    return (response) => ({});
+    return returnObject;
 }
 

--- a/packages/react-enty/src/RequestHockFactory.js
+++ b/packages/react-enty/src/RequestHockFactory.js
@@ -7,12 +7,12 @@ import type {HockMeta} from './util/definitions';
 import type {HockApplier} from './util/definitions';
 import type {Hock} from './util/definitions';
 
-import {ConnectFull} from './util/Connect';
+import Connect, {ConnectFull} from './util/Connect';
 import React from 'react';
+import memoize from 'lru-memoize';
 import RequestStateSelector from 'enty-state/lib/RequestStateSelector';
 import ErrorSelector from 'enty-state/lib/ErrorSelector';
 import {RequestHockNoNameError} from './util/Error';
-import PropChangeHoc from './util/PropChangeHoc';
 import {selectEntityByResult} from 'enty-state/lib/EntitySelector';
 import Message from 'enty-state/lib/data/Message';
 import composeWith from 'unmutable/lib/util/composeWith';
@@ -20,6 +20,14 @@ import identity from 'unmutable/lib/identity';
 import pipe from 'unmutable/lib/util/pipe';
 import pipeWith from 'unmutable/lib/util/pipeWith';
 import set from 'unmutable/lib/set';
+import setIn from 'unmutable/lib/setIn';
+import getIn from 'unmutable/lib/getIn';
+import equals from 'unmutable/lib/equals';
+
+// @intent using nature of destructuing and unused vars to
+// filter out redux props.
+// eslint-disable-next-line no-unused-vars
+const filterReduxProps = ({store, dispatch, storeSubscription, ...props}) => props;
 
 /**
  * RequestHockFactory
@@ -32,7 +40,11 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
      * @kind function
      */
     const RequestHock = pipe(
-        prepareConfig,
+        // prepare the config
+        config => pipeWith(
+            config,
+            set('mapResponseToProps', mapResponseToProps(config))
+        ),
         function (config: RequestHockConfig): HockApplier {
 
             /**
@@ -40,108 +52,144 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
              */
             function RequestHockApplier(Component: ComponentType<*>): ComponentType<*> {
 
-                const {payloadCreator = config.auto ? () => ({}) : identity()} = config;
+                const {payloadCreator = () => ({})} = config;
                 const {updateResultKey = identity()} = config;
                 const {name} = config;
+                const {optimistic = true} = config;
                 const {mapResponseToProps} = config;
+
+                // Auto Props
+                const {shouldComponentAutoRequest = () => true} = config;
+                const {auto = false} = config;
+                const paths = typeof auto === 'boolean' ? [] : auto;
 
                 if(!name) {
                     throw RequestHockNoNameError(hockMeta.requestActionName);
                 }
 
-                const RequestHock = composeWith(
-                    (ComponentWithState) => class RequestHock extends React.Component<*, *> {
-                        request: Function;
-                        constructor(props: *) {
-                            super(props);
-                            this.state = {};
+                const generateMemoedProps = memoize()((requestState, response) => ({
+                    ...(mapResponseToProps(response)),
+                    [name]: new Message({requestState, response})
+                }));
 
-                            this.request = pipe(
-                                payloadCreator,
-                                (payload: *): Promise<*> => {
-                                    const nextResultKey = updateResultKey(
-                                        config.resultKey || hockMeta.generateResultKey(payload),
-                                        props
-                                    );
-                                    this.setState({
-                                        nextResultKey,
-                                        resultKey: this.state.nextResultKey || nextResultKey
-                                    });
-                                    return actionCreator(payload, {resultKey: nextResultKey});
+                const RequestHock = composeWith(
+                    // dummy connect so we have a dispatch function
+                    Connect(() => ({}), hockMeta),
+
+                    // prepare request function
+                    // listen for prop changes
+                    // and calculate the current and next responseKey
+                    (ComponentWithState) => class RequestHock extends React.Component<*, *> {
+
+                        constructor(pollutedProps) {
+                            super(pollutedProps);
+                            const props = filterReduxProps(pollutedProps);
+                            this.state = RequestHock.deriveResponseKey(props, payloadCreator(props));
+                        }
+
+                        static getDerivedStateFromProps(pollutedProps, state) {
+                            //if(config.log) console.log('getDerivedStateFromProps', state);
+                            let resultKeys;
+                            const props = filterReduxProps(pollutedProps);
+                            const getPath = (path) => getIn(path.split('.'));
+                            const setPath = (path, value) => setIn(path.split('.'), value);
+
+                            const propsHaveChanged = paths
+                                .some((item: string): boolean => {
+                                    const previous = getPath(item)(state.previousProps || {});
+                                    const next = getPath(item)(props);
+                                    return !equals(previous)(next);
+                                });
+
+                            //!
+                            if(auto) {
+                                if(propsHaveChanged && shouldComponentAutoRequest(props) || !state.previousProps) {
+                                    //if(config.log) console.log('propChange', paths);
+                                    resultKeys = RequestHock.request(pollutedProps.dispatch, props, payloadCreator(props), state.nextResultKey);
+                                }
+                            }
+
+                            return {
+                                previousProps: paths.reduce((rr, path) => {
+                                    return setPath(path, getPath(path)(props))(rr);
+                                }, {}),
+                                ...resultKeys
+                            }
+
+                        }
+
+                        static deriveResponseKey(props, payload, existingResultKey) {
+                            return {
+                                nextResultKey: updateResultKey(
+                                    config.resultKey || hockMeta.generateResultKey(payload),
+                                    props
+                                ),
+                                resultKey: existingResultKey
+                            }
+                        }
+
+                        static request(dispatch: Function, props, payload, existingResultKey?: any) {
+                            return pipeWith(
+                                RequestHock.deriveResponseKey(props, payload, existingResultKey),
+                                nextState => {
+                                    //if(config.log) console.log('request', nextState);
+                                    dispatch(actionCreator(payload, {
+                                        resultKey: nextState.nextResultKey
+                                    }));
+                                    return nextState;
                                 }
                             );
                         }
 
                         render(): Element<any> {
-                            const props = {
+                            const newProps = {
                                 ...this.props,
                                 [name]: {
-                                    request: this.request,
-                                    nextResultKey: this.state.nextResultKey,
-                                    resultKey: this.state.resultKey
+                                    ...this.state,
+                                    onRequest: (payload) => this.setState(RequestHock.request(
+                                        this.props.dispatch,
+                                        filterReduxProps(this.props),
+                                        payload,
+                                        this.state.resultKey
+                                    ))
                                 }
                             };
-                            return <ComponentWithState {...props} />;
+                            return <ComponentWithState {...newProps} />;
                         }
                     },
                     ConnectFull(
                         // Construct name from state
-                        (state: *, props: *): * => {
+                        (state: *, ownProps: *): * => {
+                            const props = filterReduxProps(ownProps);
                             const {resultKey} = props[name];
                             const {nextResultKey} = props[name];
-                            const requestState = RequestStateSelector(state, nextResultKey, hockMeta);
+                            const {onRequest} = props[name];
+                            const requestState = RequestStateSelector(state, nextResultKey, hockMeta)
+                                .errorMap(() => null);
+
+                            const beforeSuccess = () => optimistic ? nextResultKey : resultKey;
 
                             const responseKey = requestState
-                                .emptyMap(() => resultKey)
-                                .fetchingMap(() => resultKey)
-                                .refetchingMap(() => resultKey)
+                                .emptyMap(beforeSuccess)
+                                .fetchingMap(beforeSuccess)
+                                .refetchingMap(beforeSuccess)
                                 .errorMap(() => nextResultKey)
                                 .successMap(() => nextResultKey)
                                 .value();
 
+                            const response = selectEntityByResult(state, responseKey, hockMeta);
 
-                            return {
-                                [name]: {
-                                    // @TODO rename resultKey to responseKey
-                                    resultKey: responseKey,
-                                    response: selectEntityByResult(state, responseKey, hockMeta),
-                                    requestState: RequestStateSelector(state, nextResultKey, hockMeta)
-                                        // @TODO: temoporarily remove the error from the request state
-                                        // once query hock and mutation hock are removed this can be taken out of the reduce
-                                        // requestState variants shouldnt hold any data
-                                        .errorMap(() => null),
-                                    requestError: ErrorSelector(state, nextResultKey, hockMeta)
-                                }
-                            };
-                        },
-                        // Construct dispatcher
-                        (dispatch: *, props: *): * => {
-                            const {request} = props[name];
-                            return {
-                                [name]: {
-                                    onRequest: (payload) => dispatch(request(payload))
-                                }
-                            };
-                        },
+                            const memoedProps = generateMemoedProps(requestState, response);
+                            memoedProps[name].responseKey = responseKey;
+                            memoedProps[name].onRequest = onRequest;
+                            memoedProps[name].requestError = ErrorSelector(state, nextResultKey, hockMeta);
 
-                        // Merge State and dispatch
-                        (stateProps, dispatchProps, ownProps) => {
-                            const message = config.pipe(ownProps)(new Message({
-                                ...stateProps[name],
-                                onRequest: dispatchProps[name].onRequest
-                            }));
-                            return {
-                                ...ownProps,
-                                ...(mapResponseToProps(stateProps[name].response)),
-                                [name]: message
-                            };
+                            return {...props, ...memoedProps};
                         },
+                        null,
+                        null,
                         hockMeta
                     ),
-                    PropChangeHoc({
-                        ...config,
-                        onPropChange: (props) => props[name].onRequest(props)
-                    }),
                     Component
                 );
 
@@ -156,13 +204,6 @@ export default function RequestHockFactory(actionCreator: Function, hockMeta: Ho
     return RequestHock;
 }
 
-function prepareConfig(config: RequestHockConfigInput): RequestHockConfig {
-    return pipeWith(
-        config,
-        set('mapResponseToProps', mapResponseToProps(config)),
-        set('pipe', config.pipe || (() => identity()))
-    );
-}
 
 function mapResponseToProps({name, ...config}: RequestHockConfigInput): (Object => Object) {
     if(config.mapResponseToProps === true) return identity();

--- a/packages/react-enty/src/index.js
+++ b/packages/react-enty/src/index.js
@@ -29,4 +29,4 @@ export {ErrorState} from 'enty-state/lib/data/RequestState';
 export {SuccessState} from 'enty-state/lib/data/RequestState';
 
 export type {RequestState} from 'enty-state/lib/data/RequestState';
-export type {Message} from 'enty-state/lib/data/Message';
+export type {default as Message} from 'enty-state/lib/data/Message';

--- a/packages/react-enty/src/index.js
+++ b/packages/react-enty/src/index.js
@@ -29,3 +29,4 @@ export {ErrorState} from 'enty-state/lib/data/RequestState';
 export {SuccessState} from 'enty-state/lib/data/RequestState';
 
 export type {RequestState} from 'enty-state/lib/data/RequestState';
+export type {Message} from 'enty-state/lib/data/Message';

--- a/packages/react-enty/src/util/definitions.js
+++ b/packages/react-enty/src/util/definitions.js
@@ -76,7 +76,12 @@ export type RequestHockConfigInput = {
 
     // Function to map response back and then spread it back onto props.
     // Useful for when you don't wish to fish the response out of the request message.
-    mapResponseToProps?: boolean|Object => Object
+    mapResponseToProps?: boolean|Object => Object,
+
+
+    // Dictates whether on request if  the request hock should use the new response key to
+    // denormalize data, or to use the old until the data has returned
+    optimistic?: boolean
 
 };
 
@@ -85,14 +90,15 @@ export type RequestHockConfigInput = {
  * allowing for it to always be spread
  */
 export type RequestHockConfig = {
-    name: string,
-    payloadCreator?: (props: *) => *,
-    updateResultKey?: (resultKey: string, props: *) => string,
-    resultKey?: string,
-    mapResponseToProps: Object => Object,
     auto?: boolean|Array<string>,
+    mapResponseToProps: Object => Object,
+    name: string,
+    optimistic?: boolean,
+    payloadCreator?: (props: *) => *,
+    pipe: (props: *) => (message: Message) => Message,
+    resultKey?: string,
     shouldComponentAutoRequest?: (props: *) => boolean,
-    pipe: (props: *) => (message: Message) => Message
+    updateResultKey?: (resultKey: string, props: *) => string
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5821,6 +5821,10 @@ lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-memoize@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lru-memoize/-/lru-memoize-1.1.0.tgz#073900ad72abdc67a3b455a797c7e94d7103e69a"
+
 make-dir@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"


### PR DESCRIPTION
remove: config.pipe
break: make hock optimistic by default
refactor: rewrite the internals to be able to handle optimism
fix: stop the render thrash when a responseKey changes