### PR TITLE
BREAK: make message polymorphic and less automatic

### DIFF
--- a/packages/enty-state/src/data/Message.js
+++ b/packages/enty-state/src/data/Message.js
@@ -1,32 +1,31 @@
 // @flow
-
 import RequestState from '../data/RequestState';
 import get from 'unmutable/lib/get';
 import getIn from 'unmutable/lib/getIn';
 
 
-type MessageProps = {
-    responseKey?: ?string,
-    response?: any,
+type MessageInput<R, E> = {
+    response: R,
+    requestError: E,
+    onRequest: (response: mixed) => Promise<mixed>,
     requestState?: RequestState,
-    requestError?: any,
-    onRequest?: (response: mixed) => Promise<mixed>
+    responseKey: string
 };
 
-export default class Message {
+export default class Message<R, E> {
 
+    response: R;
+    requestError: E;
     onRequest: (response: mixed) => Promise<mixed>;
+    responseKey: string;
     requestState: RequestState;
-    response: mixed;
-    requestError: mixed;
-    responseKey: ?string;
 
-    constructor(props: MessageProps = {}) {
+    constructor(props: MessageInput<R, E>) {
         this.responseKey = props.responseKey;
         this.response = props.response;
         this.requestState = props.requestState || RequestState.empty();
         this.requestError = props.requestError;
-        this.onRequest = props.onRequest || Promise.resolve;
+        this.onRequest = props.onRequest;
     }
 
 
@@ -45,13 +44,12 @@ export default class Message {
     //
     // Updating Methods
 
-    update(updater: Function): Message {
+    update(updater: Function): Message<R, E> {
         return new Message(updater(this));
     }
 
-    updateRequestState(updater: Function, messageProps?: MessageProps = {}): Message {
+    updateRequestState(updater: Function, messageProps?: MessageInput<R, E> = {}): Message<R, E> {
         return new Message({
-            ...this,
             ...messageProps,
             requestState: updater(this.requestState)
         });
@@ -61,73 +59,77 @@ export default class Message {
     //
     // empty
 
-    static empty(messageProps?: MessageProps = {}): Message {
+    static empty(messageProps: MessageInput<R, E>): Message<R, E> {
         return new Message({
             ...messageProps,
+            response: undefined,
+            requestError: undefined,
             requestState: RequestState.empty()
         });
     }
-    toEmpty(): Message {
-        return this.updateRequestState(_ => _.toEmpty());
+    toEmpty(): Message<R, E> {
+        return this.updateRequestState(_ => _.toEmpty(), {...this});
     }
 
 
     //
     // fetching
 
-    static fetching(messageProps?: MessageProps = {}): Message {
+    static fetching(messageProps?: MessageInput<R, E> = {}): Message<R, E> {
         return new Message({
             ...messageProps,
+            response: undefined,
             requestState: RequestState.fetching()
         });
     }
-    toFetching(): Message {
-        return this.updateRequestState(_ => _.toFetching());
+    toFetching(): Message<R, E> {
+        return this.updateRequestState(_ => _.toFetching(), {...this});
     }
 
 
     //
     // refetching
 
-    static refetching(response: mixed, messageProps?: MessageProps = {}): Message {
+    static refetching(response: R, messageProps?: MessageInput<R, E> = {}): Message<R, E> {
         return new Message({
             ...messageProps,
             response,
             requestState: RequestState.refetching()
         });
     }
-    toRefetching(response?: mixed): Message {
-        return this.updateRequestState(_ => _.toRefetching(), {response});
+    toRefetching(response?: R): Message<R, E> {
+        return this.updateRequestState(_ => _.toRefetching(), {...this, response});
     }
 
 
     //
     // success
 
-    static success(response: mixed, messageProps?: MessageProps = {}): Message {
+    static success(response: R, messageProps?: MessageInput<R, E> = {}): Message<R, E> {
         return new Message({
             ...messageProps,
             response,
             requestState: RequestState.success()
         });
     }
-    toSuccess(response?: mixed): Message {
-        return this.updateRequestState(_ => _.toSuccess(), {response});
+    toSuccess(response?: R): Message<R, E> {
+        return this.updateRequestState(_ => _.toSuccess(), {...this, response});
     }
+
 
 
     //
     // Error
 
-    static error(requestError: mixed, messageProps?: MessageProps = {}): Message {
+    static error(requestError: E, messageProps?: MessageInput<R, E> = {}): Message<R, E> {
         return new Message({
             ...messageProps,
             requestError,
             requestState: RequestState.error()
         });
     }
-    toError(requestError?: mixed): Message {
-        return this.updateRequestState(_ => _.toError(), {requestError});
+    toError(requestError: E): Message<R, E> {
+        return this.updateRequestState(_ => _.toError(), {...this, requestError});
     }
 }
 

--- a/packages/enty-state/src/data/__tests__/Message-test.js
+++ b/packages/enty-state/src/data/__tests__/Message-test.js
@@ -2,6 +2,13 @@
 import Message from '../Message';
 import RequestState from '../../data/RequestState';
 
+const response = {name: 'foo'};
+const responseKey = 'FOO';
+const onRequest = async () => response;
+const requestError = 'ERROR!';
+
+const messageInput = {response, responseKey, onRequest, requestError};
+
 it('will let you set responseKey, response, requestState, requestError, onRequest', () => {
     const message = new Message({
         responseKey: 'foo',
@@ -20,12 +27,11 @@ it('will let you set responseKey, response, requestState, requestError, onReques
 
 
 it('will default requestState to Empty', () => {
-    expect(new Message().requestState.isEmpty).toBe(true);
+    expect(new Message({response: null, responseKey: 'foo', onRequest: Promise.resolve, requestError: null}).requestState.isEmpty).toBe(true);
 });
 
 it('will let you update the message', () => {
-    const newMessage = Message
-        .empty({response: 'foo'})
+    const newMessage = Message.empty(messageInput)
         .update(message => ({
             ...message,
             response: 'bar'
@@ -53,8 +59,8 @@ describe('Message response methods', () => {
     });
 
     it('will not break on empty responses', () => {
-        expect(Message.empty().get('blah', '!')).toBe('!');
-        expect(Message.empty().getIn(['bar', 'blah'], '!')).toBe('!');
+        expect(Message.empty(messageInput).get('blah', '!')).toBe('!');
+        expect(Message.empty(messageInput).getIn(['bar', 'blah'], '!')).toBe('!');
     });
 
 });
@@ -77,10 +83,10 @@ describe('Message requestState methods', () => {
 
     it('will change requestState with .to functions', () => {
         expect(Message.fetching().toEmpty().requestState.isEmpty).toBe(true);
-        expect(Message.empty().toFetching().requestState.isFetching).toBe(true);
-        expect(Message.empty().toRefetching().requestState.isRefetching).toBe(true);
-        expect(Message.empty().toSuccess().requestState.isSuccess).toBe(true);
-        expect(Message.empty().toError().requestState.isError).toBe(true);
+        expect(Message.empty(messageInput).toFetching().requestState.isFetching).toBe(true);
+        expect(Message.empty(messageInput).toRefetching().requestState.isRefetching).toBe(true);
+        expect(Message.empty(messageInput).toSuccess().requestState.isSuccess).toBe(true);
+        expect(Message.empty(messageInput).toError().requestState.isError).toBe(true);
     });
 
 
@@ -88,38 +94,38 @@ describe('Message requestState methods', () => {
 
 describe('Message Constructors', () => {
     test('Message.empty will create a empty message without a response', () => {
-        const message = Message.empty({responseKey: 'bar'});
+        const message = Message.empty(messageInput);
         expect(message.response).toBeUndefined();
         expect(message.requestState.isEmpty).toBe(true);
-        expect(message.responseKey).toBe('bar');
+        expect(message.responseKey).toBe('FOO');
     });
 
     test('Message.fetching will create a fetching message without a response', () => {
-        const message = Message.fetching({responseKey: 'bar'});
+        const message = Message.fetching(messageInput);
         expect(message.response).toBeUndefined();
         expect(message.requestState.isFetching).toBe(true);
-        expect(message.responseKey).toBe('bar');
+        expect(message.responseKey).toBe('FOO');
     });
 
     test('Message.refetching will create a refetching message with a response', () => {
-        const message = Message.refetching('foo', {responseKey: 'bar'});
+        const message = Message.refetching('foo', messageInput);
         expect(message.response).toBe('foo');
         expect(message.requestState.isRefetching).toBe(true);
-        expect(message.responseKey).toBe('bar');
+        expect(message.responseKey).toBe('FOO');
     });
 
     test('Message.success will create a success message with a response', () => {
-        const message = Message.success('foo', {responseKey: 'bar'});
+        const message = Message.success('foo', messageInput);
         expect(message.response).toBe('foo');
         expect(message.requestState.isSuccess).toBe(true);
-        expect(message.responseKey).toBe('bar');
+        expect(message.responseKey).toBe('FOO');
     });
 
     test('Message.error will create a error message with requestError', () => {
-        const message = Message.error('foo', {responseKey: 'bar'});
+        const message = Message.error('foo', messageInput);
         expect(message.requestError).toBe('foo');
         expect(message.requestState.isError).toBe(true);
-        expect(message.responseKey).toBe('bar');
+        expect(message.responseKey).toBe('FOO');
     });
 
     it('will not break if nothing is passed to each constructor', () => {


### PR DESCRIPTION
You have to pass everything into the message all the time,
but that gives you types on what is in the message. Message
is mostly consumed by react-enty so its not too big a deal.