### PR TITLE
fix: apis were created with recursive duplication of all object branches

### DIFF
--- a/packages/enty-state/src/api/__test__/visitActionMap-test.js
+++ b/packages/enty-state/src/api/__test__/visitActionMap-test.js
@@ -2,7 +2,7 @@
 import visitActionMap from '../visitActionMap';
 
 it('will recurse through deep object trees', () => {
-    const visitor = jest.fn();
+    const visitor = jest.fn(value => value);
     const data = {
         foo: {
             bar: {
@@ -12,6 +12,7 @@ it('will recurse through deep object trees', () => {
         }
     };
     const output = visitActionMap(data, visitor);
+
     expect(visitor).toHaveBeenCalledTimes(2);
 });
 
@@ -31,7 +32,7 @@ it('will visit functions & record their path', () => {
 });
 
 it('preserve the given object tree', () => {
-    const visitor = jest.fn(() => 'FOO');
+    const visitor = jest.fn(value => value);
     const data = {
         foo: {
             bar: {
@@ -40,6 +41,6 @@ it('preserve the given object tree', () => {
         }
     };
     const output = visitActionMap(data, visitor);
-    expect(output.foo.bar.baz).toBe('FOO');
+    expect(output).toEqual(data);
 });
 

--- a/packages/enty-state/src/api/visitActionMap.js
+++ b/packages/enty-state/src/api/visitActionMap.js
@@ -7,19 +7,19 @@ import pipeWith from 'unmutable/lib/util/pipeWith';
 // Recurse through deep objects and apply the visitor to
 // anything that isnt another object.
 //
-export default function visitActionMap(branch: *, visitor: Function, path: string[] = [], state: * = {}): * {
+export default function visitActionMap(branch: *, visitor: Function, path: string[] = []): * {
     return pipeWith(
         branch,
         reduce(
             (reduction: *, item: *, key: string): * => {
                 if(typeof item !== 'function' && isKeyed(item)) {
-                    reduction[key] = visitActionMap(item, visitor, path.concat(key), reduction);
+                    reduction[key] = visitActionMap(item, visitor, path.concat(key));
                 } else {
                     reduction[key] = visitor(item, path.concat(key));
                 }
                 return reduction;
             },
-            state
+            {}
         ),
     );
 }


### PR DESCRIPTION
the entire reduction was being passed into each child recursion and being used as the starting point
of each child's reduction, making circular object references and appending every nested child's keys onto a single object.

this fixes the issue by using an empty object as the starting point of each new child reduction, which works because each recursed element explicitly builds all of its own keys onto its own output object.