### PR TITLE
Allow EntitySchema to override its shape's merge function

### DIFF
--- a/packages/enty/src/EntitySchema.js
+++ b/packages/enty/src/EntitySchema.js
@@ -5,6 +5,7 @@ import type {EntitySchemaOptions} from './util/definitions';
 import type {EntitySchemaInterface} from './util/definitions';
 import type {StructuralSchemaInterface} from './util/definitions';
 import type {IdAttribute} from './util/definitions';
+import type {Merge} from './util/definitions';
 
 import {UndefinedIdError} from './util/Error';
 import getIn from 'unmutable/lib/getIn';
@@ -20,9 +21,11 @@ export default class EntitySchema<A: StructuralSchemaInterface<any>> implements 
     name: string;
     _shape: A;
     id: IdAttribute;
+    merge: ?Merge;
 
     constructor(name: string, options: EntitySchemaOptions<any> = {}) {
         this.name = name;
+        this.merge = options.merge;
 
         if(options.shape === null) {
             this.shape = null;
@@ -69,7 +72,7 @@ export default class EntitySchema<A: StructuralSchemaInterface<any>> implements 
         schemas[name] = this;
 
         entities[name][id] = previousEntity
-            ? shape.merge(previousEntity, result)
+            ? (this.merge || shape.merge)(previousEntity, result)
             : result
         ;
 

--- a/packages/enty/src/__tests__/EntitySchema-test.js
+++ b/packages/enty/src/__tests__/EntitySchema-test.js
@@ -34,6 +34,19 @@ describe('configuration', () => {
         let schemaB = new EntitySchema('foo');
         expect(schemaB.shape).toBeInstanceOf(ObjectSchema);
     });
+
+    it('can override the shapes merge function', () => {
+        let schema = new EntitySchema('test', {
+            id: () => 'aa',
+            shape: new ArraySchema(new ObjectSchema({})),
+            merge: (aa, bb) => aa.concat(bb)
+        });
+
+        const {entities} = schema.normalize([{id: 1}]);
+        const secondState = schema.normalize([{id: 2}], entities);
+
+        expect(secondState.entities.test.aa).toEqual([{id: 1}, {id: 2}]);
+    });
 });
 
 

--- a/packages/enty/src/util/__tests__/isObject-test.js
+++ b/packages/enty/src/util/__tests__/isObject-test.js
@@ -1,0 +1,23 @@
+//@flow
+import isObject from '../isObject';
+
+it('should return `true` if the object is created by the `Object` constructor.', () => {
+    expect(isObject(Object.create({}))).toBe(true);
+    expect(isObject(Object.create(Object.prototype))).toBe(true);
+    expect(isObject({foo: 'bar'})).toBe(true);
+    expect(isObject({})).toBe(true);
+});
+
+it('should return `false` if the object is not created by the `Object` constructor.', () => {
+    function Foo() {this.abc = {};}
+
+    expect(isObject(/foo/)).toBe(false);
+    expect(isObject(function() {})).toBe(false);
+    expect(isObject(1)).toBe(false);
+    expect(isObject(['foo', 'bar'])).toBe(false);
+    expect(isObject([])).toBe(false);
+    expect(isObject(new Foo)).toBe(false);
+    expect(isObject(null)).toBe(false);
+    expect(isObject(Object.create(null))).toBe(false);
+
+});

--- a/packages/enty/src/util/definitions.js
+++ b/packages/enty/src/util/definitions.js
@@ -18,7 +18,8 @@ export type StructuralSchemaOptions = {
 
 export type EntitySchemaOptions<Shape> = {
     +shape?: Shape,
-    id?: (entity: Object) => string
+    id?: (entity: Object) => string,
+    merge?: Merge
 };
 
 export type CompositeEntitySchemaOptions<Shape, CompositeShape> = {

--- a/packages/enty/src/util/isObject.js
+++ b/packages/enty/src/util/isObject.js
@@ -9,9 +9,7 @@ export default function isPlainObject(o: Object): boolean {
     ctor = o.constructor;
     if (typeof ctor !== 'function') return false;
 
-    // If has modified prototype
     prot = ctor.prototype;
-    if (isObjectObject(prot) === false) return false;
 
     // If constructor does not have an Object-specific method
     if (prot.hasOwnProperty('isPrototypeOf') === false) {


### PR DESCRIPTION
When doing complicated list merging having the merge function on the shape is a bit confusing. 
Because merging happens at the entity level this lets you override the shapes merge function 
to make the schemas a little easier to read.

```js
// New convenience options
const foo = new EntitySchema('foo');
const fooList = new EntitySchema('fooList', {
    shape: {nodes: [foo]}
});

const fooListAdd = new EntitySchema('nodeList', {
    merge: (aa, bb) => update('nodes', (aNodes) => aNodes.concat(bb.nodes))(aa),
    shape: {nodes: [foo]}
});


// Old
const foo = new EntitySchema('foo');
const fooList = new EntitySchema('fooList', {
    shape: {nodes: [foo]}
});

const fooListAdd = new EntitySchema('nodeList', {
    shape: new ObjectSchema({
        nodes: new ArraySchema(foo)
    }, {
        merge: (aa, bb) => update('nodes', (aNodes) => aNodes.concat(bb.nodes))(aa),
    })
});
```