### PR TITLE
fix: request hook breaks when using observable

### DIFF
--- a/packages/enty-immutable/package.json
+++ b/packages/enty-immutable/package.json
@@ -32,6 +32,7 @@
     "babel-plugin-extract-flow-types": "^1.0.0",
     "babel-preset-blueflag": "^1.0.1",
     "blueflag-test": "^0.22.0",
+    "enty": "^1.0.0-alpha.7",
     "flow-bin": "^0.102.0",
     "immutable": "^3.8.1"
   },


### PR DESCRIPTION
`createRequestAction` now returns a promise to `RequestHook` even when observables are used,
so request hook can call .then() on the result

An alternative is to handle the promise vs observable cases differently in RequestHook,
but this gives `react-enty` potentially unnecessary knowledge that observables exist,
when a promise is sufficient to handle the timing of when data is received.
If this alternative is pursued, then the `isObservable` function would need to be shared between `enty-state` and `react-enty`.