### PR TITLE
fix for very strange issue where reduce iteration iterated too many times

### DIFF
--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -72,20 +72,24 @@ export default class ObjectSchema<A: {}> implements StructuralSchemaInterface<A>
                 if(path.indexOf(this) !== -1) {
                     return item;
                 }
-                return Object.keys(shape)
-                    .reduce((newItem: Object, key: string): Object => {
-                        const schema = get(key)(shape);
-                        const result = get(key)(newItem);
-                        const value = schema.denormalize({result, entities}, [...path, this]);
 
-                        if(value !== REMOVED_ENTITY) {
-                            newItem = set(key, value)(newItem);
-                        } else {
-                            newItem = del(key)(newItem);
-                        }
+                const keys = Object.keys(shape);
 
-                        return newItem;
-                    }, item);
+                for(let key of keys) {
+
+                    const schema = get(key)(shape);
+                    const result = get(key)(item);
+                    const value = schema.denormalize({result, entities}, [...path, this]);
+
+                    if(value !== REMOVED_ENTITY) {
+                        item = set(key, value)(item);
+                    } else {
+                        item = del(key)(item);
+                    }
+                }
+
+                return item;
+
             }
         );
     }


### PR DESCRIPTION
Very hard to replicate but in the edgiest of edge cases the reduce loop
would iterate over the first item twice. For example if Object.keys(shape)
were ['item1', 'item2'] then it would iterate with values of:

'item1'
'item1'
'item2'

That shouldn't be possible but it was definitely happening. This change
uses a for loop rather than .reduce. The reduce wasn't super necessary
as it was mutating the object anyway. This should also have a slight
performance increase.